### PR TITLE
Remove overflow auto

### DIFF
--- a/app/styles/ember-appuniversum/_c-main-container.scss
+++ b/app/styles/ember-appuniversum/_c-main-container.scss
@@ -42,5 +42,4 @@ $au-main-container-height: calc(100vh - 4.2rem) !default;
 
 .au-c-main-container__content--scroll {
   height: 100%;
-  overflow: auto;
 }


### PR DESCRIPTION
This is the cause for the ember-power-select dropdown indent on the mandatendatabank homepage. Weirdly enough removing 'display: flex;' from 'au-c-main-header__title-group' also fixes this issue but causes the header to get messed up. Removing overflow:auto does not have any impact visuals and fixes the issue on all viewport sizes.