### PR TITLE
Add date-picker component (Duetds)

### DIFF
--- a/addon/components/au-date-picker.hbs
+++ b/addon/components/au-date-picker.hbs
@@ -3,5 +3,5 @@
     <label for="date">{{@label}}</label>
   {{/if}}
 
-  <duet-date-picker {{prop localization=this.localization}} {{prop dateAdapter=this.adapter}} adapter={{@adapter}} localization={{@localization}} disabled={{@disabled}} buttonLabel={{@buttonLabel}} identifier={{@id}} value={{@value}} min={{@min}} max={{@max}} first-day-of-week={{@first-day}} ></duet-date-picker>
+  <duet-date-picker {{prop localization=this.localization}} {{prop dateAdapter=this.adapter}} adapter={{@adapter}} localization={{@localization}} disabled={{@disabled}} buttonLabel={{@buttonLabel}} identifier={{@id}} value={{@value}} min={{@min}} max={{@max}} first-day-of-week={{@first-day}} ...attributes></duet-date-picker>
 </div>

--- a/addon/components/au-date-picker.hbs
+++ b/addon/components/au-date-picker.hbs
@@ -1,0 +1,4 @@
+<div style="position:relative">
+<label for="date">Choose a date</label>
+<duet-date-picker identifier="date"></duet-date-picker>
+</div>

--- a/addon/components/au-date-picker.hbs
+++ b/addon/components/au-date-picker.hbs
@@ -1,4 +1,4 @@
 <div class="au-date-picker">
 <label for="date">{{@label}}</label>
-<duet-date-picker identifier="date"></duet-date-picker>
+<duet-date-picker identifier="date" value={{@value}} min={{@min}} max={{@max}}></duet-date-picker>
 </div>

--- a/addon/components/au-date-picker.hbs
+++ b/addon/components/au-date-picker.hbs
@@ -1,4 +1,4 @@
-<div style="position:relative">
-<label for="date">Choose a date</label>
+<div class="au-date-picker">
+<label for="date">{{@label}}</label>
 <duet-date-picker identifier="date"></duet-date-picker>
 </div>

--- a/addon/components/au-date-picker.hbs
+++ b/addon/components/au-date-picker.hbs
@@ -1,4 +1,4 @@
 <div class="au-date-picker">
 <label for="date">{{@label}}</label>
-<duet-date-picker identifier="date" value={{@value}} min={{@min}} max={{@max}}></duet-date-picker>
+  <duet-date-picker identifier={{@id}} value={{@value}} min={{@min}} max={{@max}} first-day-of-week={{@first-day}}></duet-date-picker>
 </div>

--- a/addon/components/au-date-picker.hbs
+++ b/addon/components/au-date-picker.hbs
@@ -1,4 +1,7 @@
 <div class="au-date-picker">
-<label for="date">{{@label}}</label>
-  <duet-date-picker identifier={{@id}} value={{@value}} min={{@min}} max={{@max}} first-day-of-week={{@first-day}}></duet-date-picker>
+  {{#if @label}}
+    <label for="date">{{@label}}</label>
+  {{/if}}
+
+  <duet-date-picker {{prop localization=this.localization}} {{prop dateAdapter=this.adapter}} adapter={{@adapter}} localization={{@localization}} disabled={{@disabled}} buttonLabel={{@buttonLabel}} identifier={{@id}} value={{@value}} min={{@min}} max={{@max}} first-day-of-week={{@first-day}} ></duet-date-picker>
 </div>

--- a/addon/components/au-date-picker.js
+++ b/addon/components/au-date-picker.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/addon/components/au-date-picker.js
+++ b/addon/components/au-date-picker.js
@@ -1,4 +1,88 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
+import { action } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
 
-export default Component.extend({
-});
+export default class AuDatePickerComponent extends Component {
+
+  //Default Localization
+  @tracked localization = {
+    buttonLabel: "Choose date",
+    placeholder: "DD-MM-YYYY",
+    selectedDateMessage: "Selected date is",
+    prevMonthLabel: "Previous month",
+    nextMonthLabel: "Next month",
+    monthSelectLabel: "Month",
+    yearSelectLabel: "Year",
+    closeLabel: "Close window",
+    keyboardInstruction: "You can use arrow keys to navigate dates",
+    calendarHeading: "Choose a date",
+    dayNames: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+    monthNames: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+    monthNamesShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+  }
+
+  // Default Adapter
+  @tracked adapter = {
+    parse: function(value = "", createDate) {
+      const matches = value.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/);
+      if (matches) {
+        return createDate(matches[3], matches[2], matches[1]);
+      }
+    },
+    format: function(date) {
+      return `${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`;
+    },
+  }
+
+  constructor(owner, args) {
+    super(owner, args);
+    this._assignLocalization(args);
+    this._assignAdapter(args);
+  }
+
+  @action _assignLocalization(args){
+
+    let localArgs = args.localization;
+    // Check if localization argument has been defined
+    if(localArgs){
+
+      // Check if localization argument passed in is of type object
+      if(typeof localArgs != "object"){
+        throw SyntaxError(`The passed in value for the localization argument needs to be of type "object", You passed in a "${typeof localArgs}"` ) ;
+      }
+      
+      // Update localization properties where needed
+      for (const [key, value] of Object.entries(localArgs)) {
+        if(this.localization[key]){ 
+          this.localization[key] = value;
+        } else {
+          throw Error(`"${key}" is not a property of localization, maybe it is just a typo?`);
+        }
+      }
+    }
+  }
+
+  @action _assignAdapter(args){
+    let adaptArgs = args.adapter
+    // Check if adapter argument has been defined
+    if(adaptArgs){
+
+      // Check if adapter argument passed in is of type object
+      if(typeof adaptArgs != "object"){
+        throw SyntaxError(`The passed in value for the adapter argument needs to be of type "object", You passed in a "${typeof adaptArgs}"` ) ;
+      }
+
+      // Update adapter properties where needed
+      for (const [key, value] of Object.entries(adaptArgs)) {
+        if(this.adapter[key]){ 
+          this.adapter[key] = value;
+        } else {
+          throw Error(`"${key}" is not a property of adapter, maybe it is just a typo?`);
+        }
+      }
+    }
+  }
+
+
+
+}

--- a/app/components/au-date-picker.js
+++ b/app/components/au-date-picker.js
@@ -1,0 +1,1 @@
+export { default } from '@appuniversum/ember-appuniversum/components/au-date-picker';

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -15,7 +15,13 @@ module.exports = function(defaults) {
       enabled: true,
       cascade: true,
       sourcemap: true
-    }
+    },
+    autoImport: {
+      alias: {
+        '@duetds/date-picker/loader': '@duetds/date-picker/dist/loader/index.cjs',
+      },
+    },
+
   });
 
   /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -13448,6 +13448,16 @@
         }
       }
     },
+    "ember-prop-modifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-prop-modifier/-/ember-prop-modifier-1.0.0.tgz",
+      "integrity": "sha512-xjO18Z5YOGSLuRdUEog906Kmrg2pMEPvnPeyUfW0bzqYPQ2Re1zC0+gDOPYtl7+vPaVKYztbWp/Ms164t2TltA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.1.2",
+        "ember-modifier": "^1.0.1"
+      }
+    },
     "ember-qunit": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-4.6.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@appuniversum/ember-appuniversum",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -959,6 +959,14 @@
         "minimist": "^1.2.0"
       }
     },
+    "@duetds/date-picker": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@duetds/date-picker/-/date-picker-1.0.4.tgz",
+      "integrity": "sha512-iIyFbkZkojrq/RxzGjV//UsndjQzvMt8xIYQ4/7os5cz4a2s4oSlhHfXMJFYi8h2qZgBS9lJ6vdVF8BGubKe3Q==",
+      "requires": {
+        "@stencil/core": "^2.0.3"
+      }
+    },
     "@ember-data/adapter": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-3.20.0.tgz",
@@ -1799,6 +1807,11 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true
+    },
+    "@stencil/core": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.0.3.tgz",
+      "integrity": "sha512-d4qLDN7HKwJEK+ljhknD8azpM4bF49Dv7h5yG3RF+SPo8uozDq3p5ZNj1MgZoRgzh04kXNyG/MKnD8H2QN5YVw=="
     },
     "@types/acorn": {
       "version": "4.0.5",
@@ -10298,6 +10311,51 @@
         "broccoli-sri-hash": "^2.1.0"
       }
     },
+    "ember-cli-stencil": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-stencil/-/ember-cli-stencil-1.0.0.tgz",
+      "integrity": "sha512-iXhUWsXqpq7qopCgw8pG9g973s+xDF9DrGneQOKW3KFC9lNovDT0Iz/yi04dBbNf+VJQ+UiIe0NND/dxQ8mg3A==",
+      "dev": true,
+      "requires": {
+        "broccoli-file-creator": "^2.1.1",
+        "broccoli-merge-trees": "^3.0.0",
+        "debug": "^3.1.0",
+        "ember-auto-import": "^1.5.2",
+        "ember-cli-babel": "^7.7.3",
+        "ember-cli-htmlbars": "^3.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "theredoc": "^1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ember-cli-htmlbars": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-3.1.0.tgz",
+          "integrity": "sha512-cgvRJM73IT0aePUG7oQ/afB7vSRBV3N0wu9BrWhHX2zkR7A7cUBI7KC9VPk6tbctCXoM7BRGsCC4aIjF7yrfXA==",
+          "dev": true,
+          "requires": {
+            "broccoli-persistent-filter": "^2.3.1",
+            "hash-for-dep": "^1.5.1",
+            "json-stable-stringify": "^1.0.1",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
     "ember-cli-string-helpers": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/ember-cli-string-helpers/-/ember-cli-string-helpers-4.0.7.tgz",
@@ -18059,6 +18117,12 @@
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "lodash.castarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
@@ -24918,6 +24982,12 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.6.0.tgz",
       "integrity": "sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ=="
+    },
+    "theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@appuniversum/appuniversum": "0.0.14",
     "@appuniversum/icon-font": "^1.1.0",
     "@duetds/date-picker": "^1.0.4",
-    "@ember/render-modifiers": "^1.0.2",
     "@zestia/ember-auto-focus": "^4.1.0",
     "ember-cli-babel": "^7.17.2",
     "ember-cli-htmlbars": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@appuniversum/appuniversum": "0.0.14",
     "@appuniversum/icon-font": "^1.1.0",
+    "@duetds/date-picker": "^1.0.4",
     "@ember/render-modifiers": "^1.0.2",
     "@zestia/ember-auto-focus": "^4.1.0",
     "ember-cli-babel": "^7.17.2",
@@ -60,6 +61,7 @@
     "ember-cli-release": "^1.0.0-beta.2",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
+    "ember-cli-stencil": "^1.0.0",
     "ember-cli-template-lint": "^1.0.0-beta.3",
     "ember-cli-uglify": "^3.0.0",
     "ember-click-outside": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-prop-modifier": "^1.0.0",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^7.0.0",
     "ember-source": "~3.16.0",

--- a/tests/dummy/app/components/sidebar.hbs
+++ b/tests/dummy/app/components/sidebar.hbs
@@ -135,6 +135,9 @@
               <AuNavigationLink @linkRoute="docs.components.ember-power-select">
                 Power select (draft)
               </AuNavigationLink>
+              <AuNavigationLink @linkRoute="docs.components.au-date-picker">
+                Date picker (draft)
+              </AuNavigationLink>
             </li>
           </ul>
         </li>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -36,6 +36,7 @@ Router.map(function() {
       this.route("au-modal");
       this.route("au-data-table");
       this.route("ember-power-select");
+      this.route("au-date-picker")
     });
 
     this.route("patterns", function() {

--- a/tests/dummy/app/styles/_shame.scss
+++ b/tests/dummy/app/styles/_shame.scss
@@ -22,3 +22,21 @@
     margin-left: -$au-list-horizontal-spacing/2;
   }
 }
+
+
+// DATE PICKER DEFAULT STYLE FROM GITHUB
+:root {
+  --duet-color-primary: #005fcc;
+  --duet-color-text: #333;
+  --duet-color-text-active: #fff;
+  --duet-color-button: #f5f5f5;
+  --duet-color-surface: #fff;
+  --duet-color-overlay: rgba(0, 0, 0, 0.8);
+
+  --duet-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --duet-font-normal: 400;
+  --duet-font-bold: 600;
+
+  --duet-radius: 4px;
+  --duet-z-index: 600;
+}

--- a/tests/dummy/app/templates/docs/components/au-date-picker-demo/adapter-default.js
+++ b/tests/dummy/app/templates/docs/components/au-date-picker-demo/adapter-default.js
@@ -1,0 +1,24 @@
+
+import Component from '@ember/component';
+import { tracked } from "@glimmer/tracking";
+
+export default class localizationDefault extends Component {
+
+
+    // BEGIN-SNIPPET au-date-picker-adapter.js
+
+// Default values
+@tracked adapter = {
+  parse: function(value = "", createDate) {
+    const matches = value.match(/^(\d{1,2})\.(\d{1,})\.(\d{4})$/)
+    if (matches) {
+      return createDate(matches[3], matches[2], matches[1])
+    }
+  },
+  format: function(date) {
+    return `${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`
+  },
+}
+    // END-SNIPPET
+
+}

--- a/tests/dummy/app/templates/docs/components/au-date-picker-demo/localization-default.js
+++ b/tests/dummy/app/templates/docs/components/au-date-picker-demo/localization-default.js
@@ -1,0 +1,28 @@
+
+import Component from '@ember/component';
+import { tracked } from "@glimmer/tracking";
+
+export default class localizationDefault extends Component {
+
+
+    // BEGIN-SNIPPET au-date-picker.js
+
+// Default values
+@tracked localization = {
+    buttonLabel: "Choose date",
+    placeholder: "DD/MM/YYYY",
+    selectedDateMessage: "Selected date is",
+    prevMonthLabel: "Previous month",
+    nextMonthLabel: "Next month",
+    monthSelectLabel: "Month",
+    yearSelectLabel: "Year",
+    closeLabel: "Close window",
+    keyboardInstruction: "You can use arrow keys to navigate dates",
+    calendarHeading: "Choose a date",
+    dayNames: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+    monthNames: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+    monthNamesShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+}
+    // END-SNIPPET
+
+};

--- a/tests/dummy/app/templates/docs/components/au-date-picker-demo/template.hbs
+++ b/tests/dummy/app/templates/docs/components/au-date-picker-demo/template.hbs
@@ -1,0 +1,14 @@
+
+
+
+{{#docs-demo as |demo|}}
+  {{#demo.example data-test-id="au-date-picker.hbs"}}
+
+    {{!-- BEGIN-SNIPPET au-date-picker.hbs --}}
+      <AuDatePicker @id="dateValue" @label="Choose a date" @value="2020-01-01" />
+    {{!-- END-SNIPPET --}}
+  {{/demo.example}}
+
+  {{demo.snippet "au-date-picker.hbs"}}
+  {{demo.snippet "au-date-picker.js" label="component.js"}}
+{{/docs-demo}}

--- a/tests/dummy/app/templates/docs/components/au-date-picker.md
+++ b/tests/dummy/app/templates/docs/components/au-date-picker.md
@@ -6,11 +6,30 @@
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='au-date-picker.hbs'}}
-  <AuDatePicker @label="Choose a date">
-  </AuDatePicker/>
+    <AuDatePicker @label="Choose a date" />
   {{/demo.example}}
   {{demo.snippet 'au-date-picker.hbs'}}
 {{/docs-demo}}
+
+
+## Dynamic value
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name='au-date-picker-value.hbs'}}
+    <AuDatePicker @label="Choose a date" @value="2020-01-01" />
+  {{/demo.example}}
+  {{demo.snippet 'au-date-picker-value.hbs'}}
+{{/docs-demo}}
+
+## Minimum and maximum date
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name='au-date-picker-range.hbs'}}
+    <AuDatePicker @label="Choose a date" @min="2020-01-15" @max="2020-01-23"/>
+  {{/demo.example}}
+  {{demo.snippet 'au-date-picker-range.hbs'}}
+{{/docs-demo}}
+
 
 
 

--- a/tests/dummy/app/templates/docs/components/au-date-picker.md
+++ b/tests/dummy/app/templates/docs/components/au-date-picker.md
@@ -6,7 +6,7 @@
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='au-date-picker.hbs'}}
-  <AuDatePicker>
+  <AuDatePicker @label="Choose a date">
   </AuDatePicker/>
   {{/demo.example}}
   {{demo.snippet 'au-date-picker.hbs'}}

--- a/tests/dummy/app/templates/docs/components/au-date-picker.md
+++ b/tests/dummy/app/templates/docs/components/au-date-picker.md
@@ -1,0 +1,17 @@
+# Date Picker
+
+---
+
+## Default 
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name='au-date-picker.hbs'}}
+  <AuDatePicker>
+  </AuDatePicker/>
+  {{/demo.example}}
+  {{demo.snippet 'au-date-picker.hbs'}}
+{{/docs-demo}}
+
+
+
+

--- a/tests/dummy/app/templates/docs/components/au-date-picker.md
+++ b/tests/dummy/app/templates/docs/components/au-date-picker.md
@@ -2,6 +2,7 @@
 
 ---
 
+
 ## Default 
 
 {{#docs-demo as |demo|}}
@@ -10,7 +11,6 @@
   {{/demo.example}}
   {{demo.snippet 'au-date-picker.hbs'}}
 {{/docs-demo}}
-
 
 ## Dynamic value
 
@@ -25,10 +25,36 @@
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='au-date-picker-range.hbs'}}
-    <AuDatePicker  @id="dateMinMax" @label="Choose a date" @min="2020-01-15" @max="2020-01-23"/>
+    <AuDatePicker  @id="dateMinMax" @label="Choose a date" @min="2020-01-15" @max="2020-01-23" />
   {{/demo.example}}
   {{demo.snippet 'au-date-picker-range.hbs'}}
 {{/docs-demo}}
+
+## Disabled
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name='au-date-picker-disabled.hbs'}}
+    <AuDatePicker  @id="dateDisabled" @label="Choose a date" @disabled={{true}} />
+  {{/demo.example}}
+  {{demo.snippet 'au-date-picker-disabled.hbs'}}
+{{/docs-demo}}
+
+## Localization
+
+You can customize all button labels, names, placeholders... by passing in a localization object.
+
+{{docs-snippet name="au-date-picker.js" unindent=false language=js showCopy=false}}
+
+It is not required to pass in all object properties. If you are only interested in changing the buttonLabel property value, it suffices to pass in the localization object with only buttonLabel as property. <br> <br>
+If you have multiple date pickers on one page, then you only need to pass in the localization object to a single date picker. All the others will use that localization object automatically. 
+
+## Adapter
+
+Customize how the dates are formatted and/or parsed. The adapter argument expects an object with 2 properties (parse & format). The property values have to be functions containing a return statement.
+
+{{docs-snippet name="au-date-picker-adapter.js" unindent=false language=js showCopy=false}}
+
+
 
 ## Arguments
 
@@ -40,6 +66,9 @@
 | `@min` | Set starting date | `date` | - |
 | `@max` | set ending date | `date` | - |
 | `@first-day` | Choose first day of the week (range: 1 - 7) | `Integer` | 1 |
+| `@disabled` | Makes the date picker input component disabled | `Boolean` | false |
+| `@localization` | Object for localizing Button labels, names... | `Object` | [See above](#localization) |
+| `@adapter` | Object for parsing and formatting | `Object` | [See above](#adapter) |
 
 
 

--- a/tests/dummy/app/templates/docs/components/au-date-picker.md
+++ b/tests/dummy/app/templates/docs/components/au-date-picker.md
@@ -6,7 +6,7 @@
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='au-date-picker.hbs'}}
-    <AuDatePicker @label="Choose a date" />
+    <AuDatePicker @id="dateDefault" @label="Choose a date" />
   {{/demo.example}}
   {{demo.snippet 'au-date-picker.hbs'}}
 {{/docs-demo}}
@@ -16,7 +16,7 @@
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='au-date-picker-value.hbs'}}
-    <AuDatePicker @label="Choose a date" @value="2020-01-01" />
+    <AuDatePicker @id="dateValue" @label="Choose a date" @value="2020-01-01" />
   {{/demo.example}}
   {{demo.snippet 'au-date-picker-value.hbs'}}
 {{/docs-demo}}
@@ -25,12 +25,21 @@
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='au-date-picker-range.hbs'}}
-    <AuDatePicker @label="Choose a date" @min="2020-01-15" @max="2020-01-23"/>
+    <AuDatePicker  @id="dateMinMax" @label="Choose a date" @min="2020-01-15" @max="2020-01-23"/>
   {{/demo.example}}
   {{demo.snippet 'au-date-picker-range.hbs'}}
 {{/docs-demo}}
 
+## Arguments
 
+| Argument      | Description | Type | Default value |
+| ------------- | ----------- | ---- | ------------- |
+| `@id` | Set id of component  | `required` | - |
+| `@label` | Set label text  | `String` | - |
+| `@value` | Set/get the date value  | `date` | - |
+| `@min` | Set starting date | `date` | - |
+| `@max` | set ending date | `date` | - |
+| `@first-day` | Choose first day of the week (range: 1 - 7) | `Integer` | 1 |
 
 
 

--- a/tests/integration/components/au-date-picker-test.js
+++ b/tests/integration/components/au-date-picker-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | au-date-picker', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<AuDatePicker />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <AuDatePicker>
+        template block text
+      </AuDatePicker>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION

DONE:
- Transformed Duetds date-picker into an ember-component 
- Filled out documentation with demo's and arguments
- Added error handling
- Modified the default values slightly

NOTES:
- Tested it 
- Should not interfere with existing code

TO-DO:
- Styling is default. Changes will probably need to be made, an example is when passing in the attribute disabled=true, there is no visual feedback to the date picker being disabled.
- Maybe change default formatting to something more suitable


ref: https://github.com/duetds/date-picker