### PR TITLE
Make component work again when no model is needed

### DIFF
--- a/addon/components/au-link.hbs
+++ b/addon/components/au-link.hbs
@@ -1,20 +1,24 @@
-<LinkTo @route="{{@linkRoute}}" @model={{@model}} class="au-c-link {{this.skin}} {{this.active}}" ...attributes>
-  {{#if @icon}}
-    {{#if (eq @iconAlignment "left")}}
-    <AuIcon @icon="{{@icon}}" @alignment="left" />
+{{#with (if @model
+                (component "link-to" model=@model)
+                (component "link-to" )) as |LinkTo| }}
+  <LinkTo @route={{@linkRoute}} class="au-c-link {{this.skin}} {{this.active}}" ...attributes>
+    {{#if @icon}}
+      {{#if (eq @iconAlignment "left")}}
+        <AuIcon @icon="{{@icon}}" @alignment="left"/>
+      {{/if}}
+      {{#unless @iconAlignment}}
+        <AuIcon @icon="{{@icon}}"/>
+      {{/unless}}
     {{/if}}
-    {{#unless @iconAlignment}}
-    <AuIcon @icon="{{@icon}}" />
-    {{/unless}}
-  {{/if}}
-  {{#if (eq @hideText "true")}}
-  <span class="au-u-hidden-visually">{{yield}}</span>
-  {{else}}
-  {{yield}}
-  {{/if}}
-  {{#if @icon}}
-    {{#if (eq @iconAlignment "right")}}
-    <AuIcon @icon="{{@icon}}" @alignment="right" />
+    {{#if (eq @hideText "true")}}
+      <span class="au-u-hidden-visually">{{yield}}</span>
+    {{else}}
+      {{yield}}
     {{/if}}
-  {{/if}}
-</LinkTo>
+    {{#if @icon}}
+      {{#if (eq @iconAlignment "right")}}
+        <AuIcon @icon="{{@icon}}" @alignment="right"/>
+      {{/if}}
+    {{/if}}
+  </LinkTo>
+{{/with}}


### PR DESCRIPTION
#54 actually breaks the component when no `@model` attribute is needed. This PR hopes to fix that.
The problem is that LinkTo treats a `@model` argument with the values `undefined` or `null` as invalid. 
When no model is needed for the route, the `@model` argument to LinkTo has to be entirely absent. 

## WARNING
This solution makes the behavoir of AuLink deviate from the behavior of LinkTo when the model is null or undefined. In partircular

- route doesnt need model, `@model` argument is provided but is falsey:
AuLink: works fine
LinkTo: link doesnt work and prints a warning to console when clicked

- route needs model, `@model` argument is provided but falsey:
**AuLink: link doesnt work, no warning or error** -> this could be problematic (this is the same behavior as forgetting to give the `@model` argument to linkTo, so there's gotchas either way)
LinkTo: link doesnt work and prints a warning to console when clicked