### PR TITLE
chore: remove the ember-wormhole dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@appuniversum/ember-appuniversum",
-  "version": "0.1.4",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -18299,6 +18299,7 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/ember-wormhole/-/ember-wormhole-0.5.5.tgz",
       "integrity": "sha512-z8l3gpoKmRA2BnTwvnYRk4jKVcETKHpddsD6kpS+EJ4EfyugadFS3zUqBmRDuJhFbNP8BVBLXlbbATj+Rk1Kgg==",
+      "dev": true,
       "requires": {
         "ember-cli-babel": "^6.10.0",
         "ember-cli-htmlbars": "^2.0.1"
@@ -18308,6 +18309,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
           "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+          "dev": true,
           "requires": {
             "ensure-posix-path": "^1.0.1"
           }
@@ -18316,6 +18318,7 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
           "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
+          "dev": true,
           "requires": {
             "semver": "^5.3.0"
           }
@@ -18324,6 +18327,7 @@
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
           "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
+          "dev": true,
           "requires": {
             "babel-core": "^6.26.0",
             "broccoli-funnel": "^2.0.1",
@@ -18341,6 +18345,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
           "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "merge-trees": "^1.0.1"
@@ -18350,6 +18355,7 @@
           "version": "1.4.6",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
           "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
+          "dev": true,
           "requires": {
             "async-disk-cache": "^1.2.1",
             "async-promise-queue": "^1.0.3",
@@ -18369,7 +18375,8 @@
             "rsvp": {
               "version": "3.6.2",
               "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+              "dev": true
             }
           }
         },
@@ -18377,6 +18384,7 @@
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
           "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "dev": true,
           "requires": {
             "amd-name-resolver": "1.2.0",
             "babel-plugin-debug-macros": "^0.2.0-beta.6",
@@ -18397,6 +18405,7 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.5.tgz",
           "integrity": "sha512-3f3PAxdnQ/fhQa8XP/3z4RLRgLHxV8j4Ln75aHbRdemOCjBa048KxL9l+acRLhCulbGQCMnLiIUIC89PAzLrcA==",
+          "dev": true,
           "requires": {
             "broccoli-persistent-filter": "^1.4.3",
             "hash-for-dep": "^1.2.3",
@@ -18408,6 +18417,7 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -18417,6 +18427,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
           "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+          "dev": true,
           "requires": {
             "can-symlink": "^1.0.0",
             "fs-tree-diff": "^0.5.4",
@@ -18430,6 +18441,7 @@
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -18437,12 +18449,14 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         },
         "workerpool": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
           "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
+          "dev": true,
           "requires": {
             "object-assign": "4.1.1"
           }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "ember-focus-trap": "^0.4.0",
     "ember-modifier": "^1.0.3",
     "ember-power-select": "^4.1.0",
-    "ember-prop-modifier": "^1.0.0",
-    "ember-wormhole": "^0.5.5"
+    "ember-prop-modifier": "^1.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",


### PR DESCRIPTION
Ember Wormhole is no longer used so it can safely be removed.