### PR TITLE
[Breaking change] Remove the application serializer

### DIFF
--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,7 +1,0 @@
-/* eslint-disable ember/no-mixins */
-import JSONAPISerializer from '@ember-data/serializer/json-api';
-import DataTableSerializerMixin from 'ember-data-table/mixins/serializer';
-
-export default JSONAPISerializer.extend(DataTableSerializerMixin, {
-  keyForAttribute(key) { return key; }
-});


### PR DESCRIPTION
This was exported from the app folder by accident and it should actually be added to the dummy app instead.
Since the serializer is no longer used, it can be removed instead.

This will affect projects that don't have an application serializer themselves and unknowingly depend on the one from this addon. So this will require a minor version bump (ember-appuniversum is still in the 0.X version range). 

For reference [frontend-toezicht-abb](https://github.com/lblod/frontend-toezicht-abb) is the only project that seems to rely on this behavior.