### PR TITLE
Use the root-url helper to wrap all image paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4621,15 +4621,6 @@
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
       "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg=="
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -16216,6 +16207,33 @@
             "@babel/traverse": "^7.12.1",
             "@babel/types": "^7.12.1",
             "lodash": "^4.17.19"
+          },
+          "dependencies": {
+            "@babel/helper-split-export-declaration": {
+              "version": "7.12.13",
+              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+              "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+              "requires": {
+                "@babel/types": "^7.12.13"
+              },
+              "dependencies": {
+                "@babel/helper-validator-identifier": {
+                  "version": "7.12.11",
+                  "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+                  "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+                },
+                "@babel/types": {
+                  "version": "7.13.0",
+                  "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
+                  "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+                  "requires": {
+                    "@babel/helper-validator-identifier": "^7.12.11",
+                    "lodash": "^4.17.19",
+                    "to-fast-properties": "^2.0.0"
+                  }
+                }
+              }
+            }
           }
         },
         "@babel/helper-remap-async-to-generator": {
@@ -16805,6 +16823,33 @@
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.19"
+          },
+          "dependencies": {
+            "@babel/helper-split-export-declaration": {
+              "version": "7.12.13",
+              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+              "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+              "requires": {
+                "@babel/types": "^7.12.13"
+              },
+              "dependencies": {
+                "@babel/types": {
+                  "version": "7.13.0",
+                  "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
+                  "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+                  "requires": {
+                    "@babel/helper-validator-identifier": "^7.12.11",
+                    "lodash": "^4.17.19",
+                    "to-fast-properties": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "@babel/helper-validator-identifier": {
+              "version": "7.12.11",
+              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+              "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+            }
           }
         },
         "@babel/types": {
@@ -17091,6 +17136,36 @@
             "@babel/traverse": "^7.12.1",
             "@babel/types": "^7.12.1",
             "lodash": "^4.17.19"
+          },
+          "dependencies": {
+            "@babel/helper-split-export-declaration": {
+              "version": "7.12.13",
+              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+              "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+              "dev": true,
+              "requires": {
+                "@babel/types": "^7.12.13"
+              },
+              "dependencies": {
+                "@babel/helper-validator-identifier": {
+                  "version": "7.12.11",
+                  "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+                  "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+                  "dev": true
+                },
+                "@babel/types": {
+                  "version": "7.13.0",
+                  "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
+                  "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+                  "dev": true,
+                  "requires": {
+                    "@babel/helper-validator-identifier": "^7.12.11",
+                    "lodash": "^4.17.19",
+                    "to-fast-properties": "^2.0.0"
+                  }
+                }
+              }
+            }
           }
         },
         "@babel/helper-remap-async-to-generator": {
@@ -17738,6 +17813,36 @@
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.19"
+          },
+          "dependencies": {
+            "@babel/helper-split-export-declaration": {
+              "version": "7.12.13",
+              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+              "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+              "dev": true,
+              "requires": {
+                "@babel/types": "^7.12.13"
+              },
+              "dependencies": {
+                "@babel/types": {
+                  "version": "7.13.0",
+                  "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
+                  "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+                  "dev": true,
+                  "requires": {
+                    "@babel/helper-validator-identifier": "^7.12.11",
+                    "lodash": "^4.17.19",
+                    "to-fast-properties": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "@babel/helper-validator-identifier": {
+              "version": "7.12.11",
+              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+              "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+              "dev": true
+            }
           }
         },
         "@babel/types": {
@@ -18215,6 +18320,155 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.13.tgz",
       "integrity": "sha512-m9JbwQlT6PjY7x/T8HslnXP7Sz9bx/pz3FrNfNi2NesJnbNISly0Lix6NV1fhfo46572cpq4jrM+/6yYlMefTQ=="
+    },
+    "ember-root-url": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ember-root-url/-/ember-root-url-0.2.0.tgz",
+      "integrity": "sha512-VvUCxrcqANOfTAf3p91RAJAyNCIwSmB02NDUUqo1qmmZq+kCszqcuh4g4Dd2RHPTTT+/PQuZP0AACYSu155SXA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^6.6.0"
+      },
+      "dependencies": {
+        "amd-name-resolver": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
+          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "^1.0.1"
+          }
+        },
+        "babel-plugin-debug-macros": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
+          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
+          "dev": true,
+          "requires": {
+            "semver": "^5.3.0"
+          }
+        },
+        "broccoli-babel-transpiler": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
+          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
+          "dev": true,
+          "requires": {
+            "babel-core": "^6.26.0",
+            "broccoli-funnel": "^2.0.1",
+            "broccoli-merge-trees": "^2.0.0",
+            "broccoli-persistent-filter": "^1.4.3",
+            "clone": "^2.0.0",
+            "hash-for-dep": "^1.2.3",
+            "heimdalljs-logger": "^0.1.7",
+            "json-stable-stringify": "^1.0.0",
+            "rsvp": "^4.8.2",
+            "workerpool": "^2.3.0"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^1.0.1"
+          }
+        },
+        "broccoli-persistent-filter": {
+          "version": "1.4.6",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
+          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
+          "dev": true,
+          "requires": {
+            "async-disk-cache": "^1.2.1",
+            "async-promise-queue": "^1.0.3",
+            "broccoli-plugin": "^1.0.0",
+            "fs-tree-diff": "^0.5.2",
+            "hash-for-dep": "^1.0.2",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "mkdirp": "^0.5.1",
+            "promise-map-series": "^0.2.1",
+            "rimraf": "^2.6.1",
+            "rsvp": "^3.0.18",
+            "symlink-or-copy": "^1.0.1",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "rsvp": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+              "dev": true
+            }
+          }
+        },
+        "ember-cli-babel": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "dev": true,
+          "requires": {
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "^0.2.0-beta.6",
+            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-preset-env": "^1.7.0",
+            "broccoli-babel-transpiler": "^6.5.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^2.1.2",
+            "semver": "^5.5.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
+          }
+        },
+        "merge-trees": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
+          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+          "dev": true,
+          "requires": {
+            "can-symlink": "^1.0.0",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "workerpool": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
+          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1"
+          }
+        }
+      }
     },
     "ember-router-generator": {
       "version": "2.0.0",
@@ -21155,12 +21409,6 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
     },
     "filesize": {
       "version": "4.2.1",
@@ -24963,12 +25211,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
-    },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -36602,11 +36844,7 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
+    "ember-root-url": "^0.2.0",
     "ember-source": "~3.20.2",
     "ember-source-channel-url": "^2.0.1",
     "ember-template-lint": "^3.0.0",

--- a/tests/dummy/app/templates/docs/patterns/au-content-header.md
+++ b/tests/dummy/app/templates/docs/patterns/au-content-header.md
@@ -1,34 +1,38 @@
 # Content header
 
 ---
+{{#let (concat
+  (root-url "/assets/images/loket-header-320.jpg") " 320w, "
+  (root-url "/assets/images/loket-header-1024.jpg") " 1024w, "
+  (root-url "/assets/images/loket-header-1600.jpg") " 1600w"
+) as |srcSet|}}
+  {{#docs-demo as |demo|}}
+    {{#demo.example name='au-content-header.hbs'}}
+      <AuContentHeader @titlePartOne="Vlaanderen" @titlePartTwo="is lokaal bestuur">
+        <img sizes="50vw" src={{root-url "/assets/images/loket-header-1600.jpg"}} srcset={{srcSet}} alt="Foto van een laptop met daarop het vlaanderen logo.">
+      </AuContentHeader>
+    {{/demo.example}}
+    {{demo.snippet 'au-content-header.hbs'}}
+  {{/docs-demo}}
 
-{{#docs-demo as |demo|}}
-  {{#demo.example name='au-content-header.hbs'}}
-    <AuContentHeader @titlePartOne="Vlaanderen" @titlePartTwo="is lokaal bestuur">
-      <img sizes="50vw" src="/assets/images/loket-header-1600.jpg" srcset="/assets/images/loket-header-320.jpg 320w, /assets/images/loket-header-1024.jpg 1024w, /assets/images/loket-header-1600.jpg 1600w" alt="Foto van een laptop met daarop het vlaanderen logo.">
-    </AuContentHeader>
-  {{/demo.example}}
-  {{demo.snippet 'au-content-header.hbs'}}
-{{/docs-demo}}
+  {{#docs-demo as |demo|}}
+    {{#demo.example name='au-content-header-alt.hbs'}}
+      <AuContentHeader @titlePartOne="Vlaanderen" @titlePartTwo="is lokaal bestuur">
+        <img sizes="50vw" src={{root-url "assets/images/loket-header-1600.jpg"}} srcset={{srcSet}} alt="Foto van een laptop met daarop het vlaanderen logo.">
+      </AuContentHeader>
+    {{/demo.example}}
+    {{demo.snippet 'au-content-header-alt.hbs'}}
+  {{/docs-demo}}
 
-{{#docs-demo as |demo|}}
-  {{#demo.example name='au-content-header-alt.hbs'}}
-    <AuContentHeader @titlePartOne="Vlaanderen" @titlePartTwo="is lokaal bestuur">
-      <img sizes="50vw" src="/assets/images/loket-header-1600.jpg" srcset="/assets/images/loket-header-320.jpg 320w, /assets/images/loket-header-1024.jpg 1024w, /assets/images/loket-header-1600.jpg 1600w" alt="Foto van een laptop met daarop het vlaanderen logo.">
-    </AuContentHeader>
-  {{/demo.example}}
-  {{demo.snippet 'au-content-header-alt.hbs'}}
-{{/docs-demo}}
-
-{{#docs-demo as |demo|}}
-  {{#demo.example name='au-content-header-full.hbs'}}
-    <AuContentHeader @titlePartOne="Vlaanderen" @titlePartTwo="is lokaal bestuur" @pictureSize="large">
-      <img sizes="50vw" src="/assets/images/loket-header-1600.jpg" srcset="/assets/images/loket-header-320.jpg 320w, /assets/images/loket-header-1024.jpg 1024w, /assets/images/loket-header-1600.jpg 1600w" alt="Foto van een laptop met daarop het vlaanderen logo.">
-    </AuContentHeader>
-  {{/demo.example}}
-  {{demo.snippet 'au-content-header-full.hbs'}}
-{{/docs-demo}}
-
+  {{#docs-demo as |demo|}}
+    {{#demo.example name='au-content-header-full.hbs'}}
+      <AuContentHeader @titlePartOne="Vlaanderen" @titlePartTwo="is lokaal bestuur" @pictureSize="large">
+        <img sizes="50vw" src={{root-url "/assets/images/loket-header-1600.jpg"}} srcset={{srcSet}} alt="Foto van een laptop met daarop het vlaanderen logo.">
+      </AuContentHeader>
+    {{/demo.example}}
+    {{demo.snippet 'au-content-header-full.hbs'}}
+  {{/docs-demo}}
+{{/let}}
 ## Arguments
 
 | Argument      | Description | Type | Default value |


### PR DESCRIPTION
Gh pages deploys the docs website on the `ember-appuniversum` path. This has the side effect that absolute urls to images don't work properly. prefixing them with the rootUrl fixes the problem.

Closes #64 