### PR TITLE
Prevent the closeModal callback from running twice

### DIFF
--- a/addon/components/au-modal.hbs
+++ b/addon/components/au-modal.hbs
@@ -22,7 +22,12 @@
         <h1 id="au-c-modal-title-{{@id}}" class="au-c-modal__title" tabindex="-1">
           {{@modalTitle}}
         </h1>
-        <button type="button" {{on "click" this.closeModal}} class="au-c-modal__close">
+        <button
+          class="au-c-modal__close"
+          type="button"
+          data-test-au-modal-close
+          {{on "click" this.closeModal}}
+        >
           <AuIcon @icon="cross" @size="large" />
           <span class="au-u-hidden-visually">Venster sluiten</span>
         </button>

--- a/addon/components/au-modal.js
+++ b/addon/components/au-modal.js
@@ -34,11 +34,16 @@ export default class AuModal extends Component {
     });
 
   }
+
   @action
   closeModal() {
-    this.setInert(true);
-    this.args.closeModal && this.args.closeModal();
+    // Don't run the callback when the modal is already closed.
+    // {{focus-trap}} calls closeModal when it is deactivated which also happens when the element it is attached to is destroyed.
+    // This means that this method will be called twice if the user closes the modal with something else than the escape button.
+    // (once by the click handler of the button and once when {{focus-trap}} deactivates)
+    if (this.args.modalOpen) {
+      this.setInert(true);
+      this.args.closeModal?.();
+    }
   }
-
-
 }

--- a/tests/integration/components/au-modal-test.js
+++ b/tests/integration/components/au-modal-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | au-modal', function(hooks) {
@@ -26,5 +26,31 @@ module('Integration | Component | au-modal', function(hooks) {
     // the wormhole exists outside of the test dom,
     // so we explicitly pass in the document as rootelement here
     assert.dom("#ember-appuniversum-wormhole", document).containsText('template block text');
+  });
+
+  test('it calls `@closeModal` when the modal should be closed', async function(assert) {
+    let timesCalled = 0;
+    this.set('handleClose', () => {
+      timesCalled++;
+      this.set('isOpen', false);
+    });
+
+    this.set('isOpen', true);
+
+    await render(hbs`
+      <AuModal @modalOpen={{this.isOpen}} @closeModal={{this.handleClose}}></AuModal>
+    `);
+
+    let closeButton = document.querySelector('[data-test-au-modal-close]');
+    await click(closeButton);
+    assert.equal(timesCalled, 1);
+
+    this.set('isOpen', true);
+    await triggerKeyEvent(document, 'keydown', 'Escape');
+    assert.equal(timesCalled, 2);
+
+    // Verify that it doesn't call the method when closed
+    await triggerKeyEvent(document, 'keydown', 'Escape');
+    assert.equal(timesCalled, 2);
   });
 });


### PR DESCRIPTION
If a modal was closed by pressing one of the close buttons, `@closeModal` would be called twice. This can have some side effects in apps that don't expect that behavior. The old behavior can be verified by commenting out the `if` check, and running the tests.