### PR TITLE
Make ember-power-select an optional dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@appuniversum/ember-appuniversum",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -476,7 +476,8 @@
     "@babel/helper-validator-option": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz",
-      "integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A=="
+      "integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A==",
+      "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.10.4",
@@ -583,6 +584,7 @@
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.1.tgz",
       "integrity": "sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
@@ -601,6 +603,7 @@
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.1.tgz",
       "integrity": "sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
@@ -1510,6 +1513,8 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@ember-decorators/utils/-/utils-6.1.1.tgz",
       "integrity": "sha512-0KqnoeoLKb6AyoSU65TRF5T85wmS4uDn06oARddwNPxxf/lt5jQlh41uX3W7V/fWL9tPu8x1L1Vvpc80MN1+YA==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "ember-cli-babel": "^7.1.3"
       }
@@ -1804,6 +1809,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz",
       "integrity": "sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "ember-cli-babel": "^7.10.0",
         "ember-modifier-manager-polyfill": "^1.1.0"
@@ -6434,6 +6441,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-3.0.0.tgz",
       "integrity": "sha512-NXfi+Vas24n3Ivo21GvENTI55qxKu7OwKRnCLWXld8MiLiQKQlWIq28eoARaFj0lTUFwUa4jKZeA7fW9PiWQeg==",
+      "dev": true,
       "requires": {
         "broccoli-debug": "^0.6.5",
         "broccoli-funnel": "^2.0.0",
@@ -6455,6 +6463,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz",
           "integrity": "sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==",
+          "dev": true,
           "requires": {
             "promise-map-series": "^0.2.1",
             "quick-temp": "^0.1.3",
@@ -6466,6 +6475,7 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -6476,6 +6486,7 @@
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -6484,6 +6495,7 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
           "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
@@ -8945,6 +8957,8 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/ember-assign-helper/-/ember-assign-helper-0.3.0.tgz",
       "integrity": "sha512-kDY0IRP6PUSJjghM2gIq24OD7d6XcZ1666zmZrywxEVjCenhaR0Oi/BXUU8JEATrIcXIExMIu34GKrHHlCLw0Q==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "ember-cli-babel": "^7.19.0",
         "ember-cli-htmlbars": "^4.3.1"
@@ -8953,12 +8967,16 @@
         "babel-plugin-htmlbars-inline-precompile": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz",
-          "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg=="
+          "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==",
+          "dev": true,
+          "optional": true
         },
         "broccoli-output-wrapper": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz",
           "integrity": "sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "heimdalljs-logger": "^0.1.10"
           }
@@ -8967,6 +8985,8 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
           "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "broccoli-node-api": "^1.6.0",
             "broccoli-output-wrapper": "^2.0.0",
@@ -8981,6 +9001,8 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.4.0.tgz",
           "integrity": "sha512-ohgctqk7dXIZR4TgN0xRoUYltWhghFJgqmtuswQTpZ7p74RxI9PKx+E8WV/95mGcPzraesvMNBg5utQNvcqgNg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@ember/edition-utils": "^1.2.0",
             "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
@@ -9002,6 +9024,8 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
           "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/symlink-or-copy": "^1.2.0",
             "heimdalljs-logger": "^0.1.7",
@@ -9014,6 +9038,8 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
           "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
@@ -9023,6 +9049,8 @@
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -9030,12 +9058,16 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true,
+          "optional": true
         },
         "walk-sync": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
           "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
@@ -9516,6 +9548,8 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-3.0.11.tgz",
       "integrity": "sha512-J6PFb+BGD7Md43ZJo8N2c/y0sgcoG3O1/m488XxVbb20UpIRlGXjw9Zwm8cd2f7xhSefNXsbVWyQHEkl4iXzDg==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "@ember/render-modifiers": "^1.0.2",
         "@glimmer/component": "^1.0.1",
@@ -9532,6 +9566,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/@glimmer/tracking/-/tracking-1.0.2.tgz",
           "integrity": "sha512-9Vp04TM2IDTShGFdxccfvnmcaj4NwqLrwbOXm4iju5KL/WkeB8mqoCSLtO3kUg+80DqU0pKE8tR460lQP8CutA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@glimmer/env": "^0.1.7",
             "@glimmer/validator": "^0.44.0"
@@ -12033,6 +12069,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz",
       "integrity": "sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==",
+      "dev": true,
       "requires": {
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
         "@babel/plugin-proposal-optional-chaining": "^7.6.0",
@@ -12054,6 +12091,7 @@
           "version": "7.8.7",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz",
           "integrity": "sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==",
+          "dev": true,
           "requires": {
             "@babel/helper-create-class-features-plugin": "^7.8.3",
             "@babel/helper-plugin-utils": "^7.8.3",
@@ -12064,6 +12102,7 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
           "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
             "get-stream": "^5.0.0",
@@ -12081,6 +12120,7 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -12091,6 +12131,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
           "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
@@ -12100,6 +12141,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
           "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
           "requires": {
             "path-key": "^3.0.0"
           }
@@ -12107,12 +12149,14 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         },
         "walk-sync": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
           "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
@@ -12628,6 +12672,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-1.2.1.tgz",
       "integrity": "sha512-6zlK3BndPPZlSVWq6xBohwobpDKrI58nMMDfD8OqjoeBwnaznuyVHJqDZ46NRJrvSqYX6R96XBBVpDGCCcbK+w==",
+      "dev": true,
       "requires": {
         "ember-cli-babel": "^7.7.3",
         "ember-compatibility-helpers": "^1.2.0",
@@ -12638,6 +12683,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ember-concurrency-decorators/-/ember-concurrency-decorators-2.0.1.tgz",
       "integrity": "sha512-KJ8mCZxmvgalawh/zytURsc5ParNr9avPeCDR/mE7VQxWvITHtyAuYS2s1PPFQAQggTXTZYcGnfgzjn/cDHNMQ==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "@ember-decorators/utils": "^6.1.0",
         "ember-cli-babel": "^7.19.0",
@@ -12648,12 +12695,16 @@
         "babel-plugin-htmlbars-inline-precompile": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz",
-          "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg=="
+          "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==",
+          "dev": true,
+          "optional": true
         },
         "broccoli-output-wrapper": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz",
           "integrity": "sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "heimdalljs-logger": "^0.1.10"
           }
@@ -12662,6 +12713,8 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
           "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "broccoli-node-api": "^1.6.0",
             "broccoli-output-wrapper": "^2.0.0",
@@ -12676,6 +12729,8 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.4.0.tgz",
           "integrity": "sha512-ohgctqk7dXIZR4TgN0xRoUYltWhghFJgqmtuswQTpZ7p74RxI9PKx+E8WV/95mGcPzraesvMNBg5utQNvcqgNg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@ember/edition-utils": "^1.2.0",
             "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
@@ -12697,6 +12752,8 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
           "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/symlink-or-copy": "^1.2.0",
             "heimdalljs-logger": "^0.1.7",
@@ -12709,6 +12766,8 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
           "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
@@ -12718,6 +12777,8 @@
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -12725,12 +12786,16 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true,
+          "optional": true
         },
         "walk-sync": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
           "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
@@ -12881,6 +12946,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ember-element-helper/-/ember-element-helper-0.2.0.tgz",
       "integrity": "sha512-/WV0PNLyxDvLX/YETb/8KICFTr719OYqFWXqV5XUkh9YhhBGDU/mr1OtlQaWOlsx+sHm42HD2UAICecqex8ziw==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "ember-cli-babel": "^6.16.0"
       },
@@ -12889,6 +12956,8 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
           "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "ensure-posix-path": "^1.0.1"
           }
@@ -12897,6 +12966,8 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
           "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "semver": "^5.3.0"
           }
@@ -12905,6 +12976,8 @@
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
           "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "babel-core": "^6.26.0",
             "broccoli-funnel": "^2.0.1",
@@ -12922,6 +12995,8 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
           "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "merge-trees": "^1.0.1"
@@ -12931,6 +13006,8 @@
           "version": "1.4.6",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
           "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "async-disk-cache": "^1.2.1",
             "async-promise-queue": "^1.0.3",
@@ -12950,7 +13027,9 @@
             "rsvp": {
               "version": "3.6.2",
               "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -12958,6 +13037,8 @@
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
           "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "amd-name-resolver": "1.2.0",
             "babel-plugin-debug-macros": "^0.2.0-beta.6",
@@ -12978,6 +13059,8 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -12987,6 +13070,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
           "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "can-symlink": "^1.0.0",
             "fs-tree-diff": "^0.5.4",
@@ -13000,6 +13085,8 @@
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -13008,6 +13095,8 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
           "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "object-assign": "4.1.1"
           }
@@ -15712,6 +15801,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz",
       "integrity": "sha1-NdQYKK+m1qWbwNo85H80xXPXdso=",
+      "dev": true,
       "requires": {
         "broccoli-funnel": "^1.0.1",
         "broccoli-merge-trees": "^1.0.0",
@@ -15723,6 +15813,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
           "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+          "dev": true,
           "requires": {
             "ensure-posix-path": "^1.0.1"
           }
@@ -15731,6 +15822,7 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
           "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
+          "dev": true,
           "requires": {
             "semver": "^5.3.0"
           }
@@ -15739,6 +15831,7 @@
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
           "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
+          "dev": true,
           "requires": {
             "babel-core": "^6.26.0",
             "broccoli-funnel": "^2.0.1",
@@ -15756,6 +15849,7 @@
               "version": "2.0.2",
               "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
               "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
               "requires": {
                 "array-equal": "^1.0.0",
                 "blank-object": "^1.0.1",
@@ -15776,6 +15870,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
               "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+              "dev": true,
               "requires": {
                 "broccoli-plugin": "^1.3.0",
                 "merge-trees": "^1.0.1"
@@ -15787,6 +15882,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
           "requires": {
             "array-equal": "^1.0.0",
             "blank-object": "^1.0.1",
@@ -15808,6 +15904,7 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
+          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "can-symlink": "^1.0.0",
@@ -15823,6 +15920,7 @@
           "version": "1.4.6",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
           "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
+          "dev": true,
           "requires": {
             "async-disk-cache": "^1.2.1",
             "async-promise-queue": "^1.0.3",
@@ -15842,7 +15940,8 @@
             "rsvp": {
               "version": "3.6.2",
               "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+              "dev": true
             }
           }
         },
@@ -15850,6 +15949,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -15858,6 +15958,7 @@
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
           "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "dev": true,
           "requires": {
             "amd-name-resolver": "1.2.0",
             "babel-plugin-debug-macros": "^0.2.0-beta.6",
@@ -15878,6 +15979,7 @@
               "version": "2.0.2",
               "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
               "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
               "requires": {
                 "array-equal": "^1.0.0",
                 "blank-object": "^1.0.1",
@@ -15900,6 +16002,7 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -15909,6 +16012,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
           "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+          "dev": true,
           "requires": {
             "can-symlink": "^1.0.0",
             "fs-tree-diff": "^0.5.4",
@@ -15921,17 +16025,20 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.9.6",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
-          "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck="
+          "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
+          "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -15940,6 +16047,7 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
           "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
+          "dev": true,
           "requires": {
             "object-assign": "4.1.1"
           }
@@ -15950,6 +16058,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ember-maybe-in-element/-/ember-maybe-in-element-2.0.1.tgz",
       "integrity": "sha512-Mp/HTVOGu9H7kWoq5xncVLEvPFgRuHdsqWyZ1v/gBA8Y3d2q2LdrmDK9Zg59i+cCs4oa9LrMeFyKMAbBS3vyDw==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "ember-cli-babel": "^7.21.0",
         "ember-cli-htmlbars": "^5.2.0",
@@ -15961,6 +16071,8 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.1.tgz",
           "integrity": "sha512-YziSW1MgOuVdJSyUY2CKSC4vXrGQIHF6FgygHkJOxYGjZNQYwf5MK0sbliKatvJf7kzDSnXs+r8JLrD74W/A8A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "resolve-package-path": "^2.0.0",
             "semver": "^7.3.2",
@@ -15971,6 +16083,8 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
           "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "path-root": "^0.1.1",
             "resolve": "^1.13.1"
@@ -15979,7 +16093,9 @@
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -16213,6 +16329,8 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-4.1.0.tgz",
       "integrity": "sha512-HJQDQq8riUUtrfrN69yRIOCx8hsLPGmA6/pAn8BOnmL+N+86It8d/xRpXrZBQw/Dw9cnj9EQp2Vqi0PhPBBhGg==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "@glimmer/component": "^1.0.2",
         "@glimmer/tracking": "^1.0.2",
@@ -16230,12 +16348,16 @@
         "@babel/compat-data": {
           "version": "7.12.5",
           "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.5.tgz",
-          "integrity": "sha512-DTsS7cxrsH3by8nqQSpFSyjSfSYl57D6Cf4q8dW3LK83tBKBDCkfcay1nYkXq1nIHXnpX8WMMb/O25HOy3h1zg=="
+          "integrity": "sha512-DTsS7cxrsH3by8nqQSpFSyjSfSYl57D6Cf4q8dW3LK83tBKBDCkfcay1nYkXq1nIHXnpX8WMMb/O25HOy3h1zg==",
+          "dev": true,
+          "optional": true
         },
         "@babel/core": {
           "version": "7.12.3",
           "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
           "integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@babel/generator": "^7.12.1",
@@ -16259,6 +16381,8 @@
           "version": "7.12.5",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
           "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/types": "^7.12.5",
             "jsesc": "^2.5.1",
@@ -16269,6 +16393,8 @@
           "version": "7.12.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz",
           "integrity": "sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/compat-data": "^7.12.5",
             "@babel/helper-validator-option": "^7.12.1",
@@ -16280,6 +16406,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
           "integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-function-name": "^7.10.4",
             "@babel/helper-member-expression-to-functions": "^7.12.1",
@@ -16292,6 +16420,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.1.tgz",
           "integrity": "sha512-rsZ4LGvFTZnzdNZR5HZdmJVuXK8834R5QkF3WvcnBhrlVtF0HSIUC6zbreL9MgjTywhKokn8RIYRiq99+DLAxA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-annotate-as-pure": "^7.10.4",
             "@babel/helper-regex": "^7.10.4",
@@ -16302,6 +16432,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
           "integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/types": "^7.12.1"
           }
@@ -16310,6 +16442,8 @@
           "version": "7.12.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
           "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/types": "^7.12.5"
           }
@@ -16318,6 +16452,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
           "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-module-imports": "^7.12.1",
             "@babel/helper-replace-supers": "^7.12.1",
@@ -16334,6 +16470,8 @@
               "version": "7.12.13",
               "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
               "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "@babel/types": "^7.12.13"
               },
@@ -16341,12 +16479,16 @@
                 "@babel/helper-validator-identifier": {
                   "version": "7.12.11",
                   "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-                  "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+                  "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+                  "dev": true,
+                  "optional": true
                 },
                 "@babel/types": {
                   "version": "7.13.0",
                   "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
                   "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "@babel/helper-validator-identifier": "^7.12.11",
                     "lodash": "^4.17.19",
@@ -16361,6 +16503,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
           "integrity": "sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-annotate-as-pure": "^7.10.4",
             "@babel/helper-wrap-function": "^7.10.4",
@@ -16371,6 +16515,8 @@
           "version": "7.12.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
           "integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-member-expression-to-functions": "^7.12.1",
             "@babel/helper-optimise-call-expression": "^7.10.4",
@@ -16382,6 +16528,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
           "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/types": "^7.12.1"
           }
@@ -16390,6 +16538,8 @@
           "version": "7.11.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
           "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/types": "^7.11.0"
           }
@@ -16398,6 +16548,8 @@
           "version": "7.12.5",
           "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
           "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/template": "^7.10.4",
             "@babel/traverse": "^7.12.5",
@@ -16407,12 +16559,16 @@
         "@babel/parser": {
           "version": "7.12.5",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-          "integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ=="
+          "integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
+          "dev": true,
+          "optional": true
         },
         "@babel/plugin-proposal-async-generator-functions": {
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
           "integrity": "sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/helper-remap-async-to-generator": "^7.12.1",
@@ -16423,6 +16579,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz",
           "integrity": "sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/plugin-syntax-dynamic-import": "^7.8.0"
@@ -16432,6 +16590,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz",
           "integrity": "sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/plugin-syntax-json-strings": "^7.8.0"
@@ -16441,6 +16601,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz",
           "integrity": "sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
@@ -16450,6 +16612,8 @@
           "version": "7.12.5",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.5.tgz",
           "integrity": "sha512-UiAnkKuOrCyjZ3sYNHlRlfuZJbBHknMQ9VMwVeX97Ofwx7RpD6gS2HfqTCh8KNUQgcOm8IKt103oR4KIjh7Q8g==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/plugin-syntax-numeric-separator": "^7.10.4"
@@ -16459,6 +16623,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz",
           "integrity": "sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
@@ -16469,6 +16635,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.1.tgz",
           "integrity": "sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
@@ -16478,6 +16646,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.1.tgz",
           "integrity": "sha512-c2uRpY6WzaVDzynVY9liyykS+kVU+WRZPMPYpkelXH8KBt1oXoI89kPbZKKG/jDT5UK92FTW2fZkZaJhdiBabw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
@@ -16488,6 +16658,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.12.1.tgz",
           "integrity": "sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-create-class-features-plugin": "^7.12.1",
             "@babel/helper-plugin-utils": "^7.10.4"
@@ -16497,6 +16669,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz",
           "integrity": "sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-create-regexp-features-plugin": "^7.12.1",
             "@babel/helper-plugin-utils": "^7.10.4"
@@ -16506,6 +16680,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
           "integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16514,6 +16690,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
           "integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16522,6 +16700,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.1.tgz",
           "integrity": "sha512-UZNEcCY+4Dp9yYRCAHrHDU+9ZXLYaY9MgBXSRLkB9WjYFRR6quJBumfVrEkUxrePPBwFcpWfNKXqVRQQtm7mMA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16530,6 +16710,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz",
           "integrity": "sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16538,6 +16720,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
           "integrity": "sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-module-imports": "^7.12.1",
             "@babel/helper-plugin-utils": "^7.10.4",
@@ -16548,6 +16732,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz",
           "integrity": "sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16556,6 +16742,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz",
           "integrity": "sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16564,6 +16752,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz",
           "integrity": "sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-annotate-as-pure": "^7.10.4",
             "@babel/helper-define-map": "^7.10.4",
@@ -16579,6 +16769,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz",
           "integrity": "sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16587,6 +16779,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz",
           "integrity": "sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16595,6 +16789,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz",
           "integrity": "sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-create-regexp-features-plugin": "^7.12.1",
             "@babel/helper-plugin-utils": "^7.10.4"
@@ -16604,6 +16800,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz",
           "integrity": "sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16612,6 +16810,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz",
           "integrity": "sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
             "@babel/helper-plugin-utils": "^7.10.4"
@@ -16621,6 +16821,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz",
           "integrity": "sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16629,6 +16831,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz",
           "integrity": "sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-function-name": "^7.10.4",
             "@babel/helper-plugin-utils": "^7.10.4"
@@ -16638,6 +16842,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz",
           "integrity": "sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16646,6 +16852,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz",
           "integrity": "sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16654,6 +16862,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz",
           "integrity": "sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-module-transforms": "^7.12.1",
             "@babel/helper-plugin-utils": "^7.10.4",
@@ -16665,6 +16875,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz",
           "integrity": "sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-hoist-variables": "^7.10.4",
             "@babel/helper-module-transforms": "^7.12.1",
@@ -16677,6 +16889,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz",
           "integrity": "sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-module-transforms": "^7.12.1",
             "@babel/helper-plugin-utils": "^7.10.4"
@@ -16686,6 +16900,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz",
           "integrity": "sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-create-regexp-features-plugin": "^7.12.1"
           }
@@ -16694,6 +16910,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz",
           "integrity": "sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16702,6 +16920,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz",
           "integrity": "sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/helper-replace-supers": "^7.12.1"
@@ -16711,6 +16931,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz",
           "integrity": "sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16719,6 +16941,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz",
           "integrity": "sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16727,6 +16951,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz",
           "integrity": "sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "regenerator-transform": "^0.14.2"
           }
@@ -16735,6 +16961,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz",
           "integrity": "sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16743,6 +16971,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.1.tgz",
           "integrity": "sha512-Ac/H6G9FEIkS2tXsZjL4RAdS3L3WHxci0usAnz7laPWUmFiGtj7tIASChqKZMHTSQTQY6xDbOq+V1/vIq3QrWg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-module-imports": "^7.12.1",
             "@babel/helper-plugin-utils": "^7.10.4",
@@ -16754,6 +16984,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",
           "integrity": "sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16762,6 +16994,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz",
           "integrity": "sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
@@ -16771,6 +17005,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.1.tgz",
           "integrity": "sha512-CiUgKQ3AGVk7kveIaPEET1jNDhZZEl1RPMWdTBE1799bdz++SwqDHStmxfCtDfBhQgCl38YRiSnrMuUMZIWSUQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/helper-regex": "^7.10.4"
@@ -16780,6 +17016,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz",
           "integrity": "sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16788,6 +17026,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz",
           "integrity": "sha512-EPGgpGy+O5Kg5pJFNDKuxt9RdmTgj5sgrus2XVeMp/ZIbOESadgILUbm50SNpghOh3/6yrbsH+NB5+WJTmsA7Q==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16796,6 +17036,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.1.tgz",
           "integrity": "sha512-VrsBByqAIntM+EYMqSm59SiMEf7qkmI9dqMt6RbD/wlwueWmYcI0FFK5Fj47pP6DRZm+3teXjosKlwcZJ5lIMw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-create-class-features-plugin": "^7.12.1",
             "@babel/helper-plugin-utils": "^7.10.4",
@@ -16806,6 +17048,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz",
           "integrity": "sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
@@ -16814,6 +17058,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz",
           "integrity": "sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-create-regexp-features-plugin": "^7.12.1",
             "@babel/helper-plugin-utils": "^7.10.4"
@@ -16823,6 +17069,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
           "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "core-js": "^2.6.5",
             "regenerator-runtime": "^0.13.4"
@@ -16832,6 +17080,8 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.1.tgz",
           "integrity": "sha512-H8kxXmtPaAGT7TyBvSSkoSTUK6RHh61So05SyEbpmr0MCZrsNYn7mGMzzeYoOUCdHzww61k8XBft2TaES+xPLg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/compat-data": "^7.12.1",
             "@babel/helper-compilation-targets": "^7.12.1",
@@ -16905,6 +17155,8 @@
               "version": "7.12.1",
               "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
               "integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "@babel/helper-create-class-features-plugin": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4"
@@ -16914,6 +17166,8 @@
               "version": "7.12.1",
               "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz",
               "integrity": "sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "@babel/helper-module-transforms": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4",
@@ -16926,6 +17180,8 @@
           "version": "7.12.5",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
           "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -16934,6 +17190,8 @@
           "version": "7.12.5",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
           "integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@babel/generator": "^7.12.5",
@@ -16950,6 +17208,8 @@
               "version": "7.12.13",
               "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
               "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "@babel/types": "^7.12.13"
               },
@@ -16958,6 +17218,8 @@
                   "version": "7.13.0",
                   "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
                   "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "@babel/helper-validator-identifier": "^7.12.11",
                     "lodash": "^4.17.19",
@@ -16969,7 +17231,9 @@
             "@babel/helper-validator-identifier": {
               "version": "7.12.11",
               "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-              "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+              "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -16977,6 +17241,8 @@
           "version": "7.12.6",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
           "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -16987,6 +17253,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/@glimmer/tracking/-/tracking-1.0.2.tgz",
           "integrity": "sha512-9Vp04TM2IDTShGFdxccfvnmcaj4NwqLrwbOXm4iju5KL/WkeB8mqoCSLtO3kUg+80DqU0pKE8tR460lQP8CutA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@glimmer/env": "^0.1.7",
             "@glimmer/validator": "^0.44.0"
@@ -16996,6 +17264,8 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.2.0.tgz",
           "integrity": "sha512-k5gyC1kUDyZDcdD8LMGTI7KA+cHdKainuWpmc7d5yv42WgZFO75njPi3hZchEGsFFXtSqm9jiahgvLBUV8E8mA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "ember-rfc176-data": "^0.3.16"
           }
@@ -17004,6 +17274,8 @@
           "version": "7.8.0",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.8.0.tgz",
           "integrity": "sha512-dv30Td5uL7dO3NzQUqQKQs+Iq7JGKnCNtvc6GBO76uVPqGnRlsQZcYqdBVr33JrctR+ZrpTUf7TjsFKeDRFA8Q==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/core": "^7.12.0",
             "@babel/polyfill": "^7.11.5",
@@ -17023,6 +17295,8 @@
           "version": "4.14.7",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
           "integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "caniuse-lite": "^1.0.30001157",
             "colorette": "^1.2.1",
@@ -17034,12 +17308,16 @@
         "electron-to-chromium": {
           "version": "1.3.603",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.603.tgz",
-          "integrity": "sha512-J8OHxOeJkoSLgBXfV9BHgKccgfLMHh+CoeRo6wJsi6m0k3otaxS/5vrHpMNSEYY4MISwewqanPOuhAtuE8riQQ=="
+          "integrity": "sha512-J8OHxOeJkoSLgBXfV9BHgKccgfLMHh+CoeRo6wJsi6m0k3otaxS/5vrHpMNSEYY4MISwewqanPOuhAtuE8riQQ==",
+          "dev": true,
+          "optional": true
         },
         "ember-cli-babel": {
           "version": "7.23.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.23.0.tgz",
           "integrity": "sha512-ix58DlRDAbGITtdJoRUPcAoQwKLYr/x/kIXjU9u1ATyhmuUjqb+0FDXghOWbkNihGiNOqBBR49+LBgK9AeBcNw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@babel/core": "^7.12.0",
             "@babel/helper-compilation-targets": "^7.12.0",
@@ -17072,27 +17350,37 @@
         "ember-cli-babel-plugin-helpers": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz",
-          "integrity": "sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw=="
+          "integrity": "sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==",
+          "dev": true,
+          "optional": true
         },
         "ember-rfc176-data": {
           "version": "0.3.16",
           "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.16.tgz",
-          "integrity": "sha512-IYAzffS90r2ybAcx8c2qprYfkxa70G+/UPkxMN1hw55DU5S2aLOX6v3umKDZItoRhrvZMCnzwsdfKSrKdC9Wbg=="
+          "integrity": "sha512-IYAzffS90r2ybAcx8c2qprYfkxa70G+/UPkxMN1hw55DU5S2aLOX6v3umKDZItoRhrvZMCnzwsdfKSrKdC9Wbg==",
+          "dev": true,
+          "optional": true
         },
         "escalade": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-          "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+          "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+          "dev": true,
+          "optional": true
         },
         "node-releases": {
           "version": "1.1.67",
           "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-          "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
+          "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
+          "dev": true,
+          "optional": true
         },
         "regexpu-core": {
           "version": "4.7.1",
           "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
           "integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "regenerate": "^1.4.0",
             "regenerate-unicode-properties": "^8.2.0",
@@ -20848,6 +21136,8 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/ember-text-measurer/-/ember-text-measurer-0.6.0.tgz",
       "integrity": "sha512-/aZs2x2i6kT4a5tAW+zenH2wg8AbRK9jKxLkbVsKl/1ublNl27idVRdov1gJ+zgWu3DNK7whcfVycXtlaybYQw==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "ember-cli-babel": "^7.19.0",
         "ember-cli-htmlbars": "^4.3.1"
@@ -20856,12 +21146,16 @@
         "babel-plugin-htmlbars-inline-precompile": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz",
-          "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg=="
+          "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==",
+          "dev": true,
+          "optional": true
         },
         "broccoli-output-wrapper": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz",
           "integrity": "sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "heimdalljs-logger": "^0.1.10"
           }
@@ -20870,6 +21164,8 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
           "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "broccoli-node-api": "^1.6.0",
             "broccoli-output-wrapper": "^2.0.0",
@@ -20884,6 +21180,8 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.4.0.tgz",
           "integrity": "sha512-ohgctqk7dXIZR4TgN0xRoUYltWhghFJgqmtuswQTpZ7p74RxI9PKx+E8WV/95mGcPzraesvMNBg5utQNvcqgNg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@ember/edition-utils": "^1.2.0",
             "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
@@ -20905,6 +21203,8 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
           "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/symlink-or-copy": "^1.2.0",
             "heimdalljs-logger": "^0.1.7",
@@ -20917,6 +21217,8 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
           "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
@@ -20926,6 +21228,8 @@
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -20933,12 +21237,16 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true,
+          "optional": true
         },
         "walk-sync": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
           "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
@@ -22090,7 +22398,8 @@
     "exists-sync": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz",
-      "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk="
+      "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=",
+      "dev": true
     },
     "exit": {
       "version": "0.1.2",
@@ -24205,7 +24514,8 @@
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true
     },
     "humanize-ms": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "ember-focus-trap": "^0.5.0",
     "ember-in-element-polyfill": "^1.0.0",
     "ember-modifier": "^1.0.3",
-    "ember-power-select": "^4.1.0",
     "ember-prop-modifier": "^1.0.0",
     "ember-test-selectors": "^5.0.0"
   },
@@ -72,6 +71,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-power-select": "^4.1.0",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
     "ember-root-url": "^0.2.0",
@@ -87,6 +87,9 @@
     "qunit-dom": "^1.2.0",
     "sass": "^1.26.2",
     "svg-symbols": "^1.0.5"
+  },
+  "optionalDependencies": {
+    "ember-power-select": "2.x || 3.x || 4.x"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/tests/dummy/app/templates/docs/atoms/ember-power-select.md
+++ b/tests/dummy/app/templates/docs/atoms/ember-power-select.md
@@ -2,7 +2,7 @@
 
 ---
 
-Styling of [https://ember-power-select.com/](https://ember-power-select.com/)
+`@appuniversum/ember-appuniversum` only provides styles for [ember-power-select](https://ember-power-select.com/). If you want to use the components make sure the `ember-power-select` [addon is installed](https://ember-power-select.com/docs/installation) first. Once installed, replace the styles provided by the addon (`@import "ember-power-select";`) with the appuniversum version (`@import "ember-appuniversum/p-ember-power-select";`).
 
 ## Single select
 


### PR DESCRIPTION
This addon only provides styles so the dependency isn't needed. Consuming projects can choose if they want to use ember-power-select by installing the addon and importing the styles.

Closes #92 