### PR TITLE
Remove the YUIDoc comment annotations

### DIFF
--- a/addon/components/au-time-picker.js
+++ b/addon/components/au-time-picker.js
@@ -2,9 +2,6 @@ import Component from '@ember/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-/**
-  @class AuTimePickerComponent
-*/
 export default class AuTimePickerComponent extends Component {
   @tracked hourValue = this.hours || 12;
   @tracked minuteValue = this.minutes || 0;
@@ -19,12 +16,10 @@ export default class AuTimePickerComponent extends Component {
     };
   }
 
-  /**
+  /*
    * Increments or decrements a time value.
    * HourValue has a max of 24 while minute & seconds have a max of 60
    * HourValue has a min of 1 while minute  seconds have a min of 0
-   *
-   * @method
    */
 
   @action
@@ -68,14 +63,12 @@ export default class AuTimePickerComponent extends Component {
     this.callBackParent(this.getTimeObject);
   }
 
-  /**
+  /*
    * Triggers on keydown
    * up arrow (38) increments the current value
    * down arrow (40) decrements the current value
    * If any other key that up or down has been pressed then check if it is a number key or one
    * of the allowed keys (left/right/shift/enter..) in the keyCodes list
-   *
-   * @method
    */
 
   @action
@@ -94,12 +87,10 @@ export default class AuTimePickerComponent extends Component {
     }
   }
 
-  /**
+  /*
    * triggered after focussing out of field. Checks if the inputted value makes sense. (e.g. hour range: 1 - 24)
    * "elem" is the name of the tracked property
    * "e" is the context
-   *
-   * @method
    */
 
   @action
@@ -127,10 +118,8 @@ export default class AuTimePickerComponent extends Component {
     this.callBackParent(this.getTimeObject);
   }
 
-  /**
+  /*
    * calls the function assigned to @onChange by the user with the timeObject as argument
-   *
-   * @method
    */
 
   @action


### PR DESCRIPTION
These generate menu items that are not needed. This also changes the comments to a single asterisk version to prevent YUIDoc from throwing build warnings.

Sorry about that :smile:.

Closes #100 