### PR TITLE
Prevent that the @closeModal action is run more than once

### DIFF
--- a/addon/components/au-modal.js
+++ b/addon/components/au-modal.js
@@ -37,11 +37,16 @@ export default class AuModal extends Component {
 
   @action
   closeModal() {
-    // Don't run the callback when the modal is already closed.
+    // Prevent that the @closeModal action is run more than once.
     // {{focus-trap}} calls closeModal when it is deactivated which also happens when the element it is attached to is destroyed.
     // This means that this method will be called twice if the user closes the modal with something else than the escape button.
-    // (once by the click handler of the button and once when {{focus-trap}} deactivates)
-    if (this.args.modalOpen) {
+    // (once by the click handler of the close button and once when {{focus-trap}} deactivates)
+    // It would be better if focus-trap exposed events that would be called when Escape is pressed, or the user clicks outside of the trap
+    // That way we replace `onDeactivate` with those events and this check wouldn't be needed anymore.
+    //
+    // More information: https://github.com/josemarluedke/ember-focus-trap/issues/36#issuecomment-850844483
+    // new focus-trap events issue: https://github.com/focus-trap/focus-trap/issues/126
+    if (!this.isDestroying && this.args.modalOpen) {
       this.setInert(true);
       this.args.closeModal?.();
     }

--- a/tests/integration/components/au-modal-test.js
+++ b/tests/integration/components/au-modal-test.js
@@ -53,4 +53,25 @@ module('Integration | Component | au-modal', function(hooks) {
     await triggerKeyEvent(document, 'keydown', 'Escape');
     assert.equal(timesCalled, 2);
   });
+
+  test('it calls @onClose only once when the component is rendered conditionally', async function(assert) {
+    let timesCalled = 0;
+    this.handleClose = () => {
+      timesCalled++;
+      this.set('showModal', false);
+    };
+
+    this.showModal = true;
+
+    await render(hbs`
+      {{#if this.showModal}}
+        <AuModal @modalOpen={{true}} @closeModal={{this.handleClose}}></AuModal>
+        <button data-test-close-button type="button" {{on "click" this.handleClose}}>Close modal</button>
+      {{/if}}
+    `);
+
+    let closeButton = document.querySelector('[data-test-close-button]');
+    await click(closeButton);
+    assert.equal(timesCalled, 1);
+  });
 });


### PR DESCRIPTION
The [previous fix](https://github.com/appuniversum/ember-appuniversum/pull/94) didn't cover the case where the modal was conditionally rendered (and you set `@modalOpen` to always be `true`). In that case if you completely destroy the modal component, the `@closeModal` action is still getting called twice. 

As I explained [here](https://github.com/josemarluedke/ember-focus-trap/issues/36#issuecomment-850844483) I think the root of this issue is that we are misusing the `onDeactivate` event while we are not interested in the "deactivate" part at all. We only want to know if the user wants to close the modal by pressing escape (or clicking outside of it). `onDeactivate` is the only option though since focus-trap doesn't have dedicated events for that ([yet](https://github.com/focus-trap/focus-trap/issues/126)).

Anyway this should fix it until focus-trap has a new API which covers our use-case better.