### PR TITLE
Add new button skins to the `<AuLink>` component

### DIFF
--- a/addon/components/au-link.hbs
+++ b/addon/components/au-link.hbs
@@ -1,7 +1,7 @@
 <LinkTo
   @route={{@linkRoute}}
   @models={{au-link-to-models @model @models}}
-  class="au-c-link {{this.skin}} {{this.active}}"
+  class="{{this.skin}} {{this.active}}"
   ...attributes
 >
   {{#if @icon}}

--- a/addon/components/au-link.js
+++ b/addon/components/au-link.js
@@ -1,17 +1,25 @@
 import Component from '@glimmer/component';
 
+const SKIN_CLASSES = {
+  primary: 'au-c-link',
+  secondary: 'au-c-link au-c-link--secondary',
+  button: 'au-c-button',
+  'button-link': 'au-c-button au-c-button-secondary',
+};
+
 export default class AuLink extends Component {
   get skin() {
-    if (this.args.skin == "secondary")
-      return "au-c-link--secondary";
-    else
-      return "";
+    if (SKIN_CLASSES[this.args.skin]) {
+      return SKIN_CLASSES[this.args.skin];
+    } else {
+      return SKIN_CLASSES.primary;
+    }
   }
 
   get active() {
     if (this.args.active)
-      return "is-active";
+      return 'is-active';
     else
-      return "";
+      return '';
   }
 }

--- a/tests/dummy/app/templates/docs/atoms/au-link.md
+++ b/tests/dummy/app/templates/docs/atoms/au-link.md
@@ -15,6 +15,18 @@
     <AuLink @linkRoute="docs.atoms.au-link" @skin="secondary">
       Secondary link
     </AuLink>
+
+    <hr>
+
+    <AuLink @linkRoute="docs.atoms.au-link" @skin="button">
+      Link styled as a button
+    </AuLink>
+
+    <hr>
+
+    <AuLink @linkRoute="docs.atoms.au-link" @skin="button-secondary">
+      Link styled as a secondary button
+    </AuLink>
   {{/demo.example}}
   {{demo.snippet 'au-link-skin.hbs'}}
 {{/docs-demo}}
@@ -58,7 +70,7 @@
 | Argument      | Description | Type | Default value |
 | ------------- | ----------- | ---- | ------------- |
 | `@linkRoute` | The route that is passed to the link  | `route name` | - |
-| `@skin` | Defines the style of the link  | `value`: `primary` / `secondary` | `primary` |
+| `@skin` | Defines the style of the link  | Valid skin options: <br> `primary` / `secondary` / `button` / `button-secondary` | `primary` |
 | `@icon` | Adds an icon  | `value`: <AuLink @linkRoute="docs.atoms.au-icon">Find the options here</AuLink> | - |
 | `@iconAlignment` | Choose the position of the icon, adds correct margin next to the icon | `value`: `left` / `right` | - |
 | `@hideText` | Hides the link text visually | `Boolean` | `false` |


### PR DESCRIPTION
This makes it possible to style links as buttons by using the `button` or `button-secondary` skins. Let me know if I need to use different skin names.

Closes #110 