### PR TITLE
Add a `@query` argument to the link components

### DIFF
--- a/addon/components/au-link.hbs
+++ b/addon/components/au-link.hbs
@@ -1,6 +1,7 @@
 <LinkTo
   @route={{@linkRoute}}
   @models={{au-link-to-models @model @models}}
+  @query={{@query}}
   class="{{this.skin}} {{this.active}}"
   ...attributes
 >

--- a/addon/components/au-navigation-link.hbs
+++ b/addon/components/au-navigation-link.hbs
@@ -1,6 +1,7 @@
 <LinkTo
   @route={{@linkRoute}}
   @models={{au-link-to-models @model @models}}
+  @query={{@query}}
   class="au-c-list-navigation__link" ...attributes
   {{on "click" this.linkFocus}}
 >

--- a/tests/dummy/app/templates/docs/atoms/au-link.md
+++ b/tests/dummy/app/templates/docs/atoms/au-link.md
@@ -76,3 +76,4 @@
 | `@hideText` | Hides the link text visually | `Boolean` | `false` |
 | `@active` | Adds an active state and disables pointer events | `Boolean` | `false` |
 | `@model` / `@models` | [Supply a model to the route](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/input?anchor=LinkTo#supplying-a-model) | `route model(s)` | - |
+| `@query` | [Supply query parameters to the route](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/input?anchor=LinkTo#supplying-query-parameters) | `query params as key value pairs` | - |

--- a/tests/dummy/app/templates/docs/atoms/au-navigation-link.md
+++ b/tests/dummy/app/templates/docs/atoms/au-navigation-link.md
@@ -26,3 +26,4 @@
 | ------------- | ----------- | ---- | ------------- |
 | `@linkRoute` | The route that is passed to the link  | `route name` | - |
 | `@model` / `@models` | [Supply a model to the route](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/input?anchor=LinkTo#supplying-a-model) | `route model(s)` | - |
+| `@query` | [Supply query parameters to the route](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/input?anchor=LinkTo#supplying-query-parameters) | `query params as key value pairs` | - |


### PR DESCRIPTION
This can be used to provide query parameters to the route.

Closes #88 