### PR TITLE
Deprecate the @linkRoute argument for the link components

### DIFF
--- a/addon/components/au-link.hbs
+++ b/addon/components/au-link.hbs
@@ -1,5 +1,5 @@
 <LinkTo
-  @route={{@linkRoute}}
+  @route={{this.route}}
   @models={{au-link-to-models @model @models}}
   class="{{this.skin}} {{this.active}}"
   ...attributes

--- a/addon/components/au-link.js
+++ b/addon/components/au-link.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { deprecate } from '@ember/debug';
 
 const SKIN_CLASSES = {
   primary: 'au-c-link',
@@ -8,6 +9,29 @@ const SKIN_CLASSES = {
 };
 
 export default class AuLink extends Component {
+  get route() {
+    if (this.args.linkRoute) {
+      deprecate(
+        '@linkRoute is deprecated, use @route instead',
+        false,
+        {
+          id: '@appuniversum/ember-appuniversum.au-link.linkRoute-argument',
+          until: "0.7.0",
+          for: '@appuniversum/ember-appuniversum',
+          since: {
+            enabled: '0.5.0'
+          }
+        }
+      );
+
+      return this.args.linkRoute;
+    } else if (this.args.route) {
+      return this.args.route;
+    } else {
+      return undefined;
+    }
+  }
+
   get skin() {
     if (SKIN_CLASSES[this.args.skin]) {
       return SKIN_CLASSES[this.args.skin];

--- a/addon/components/au-main-header.hbs
+++ b/addon/components/au-main-header.hbs
@@ -17,7 +17,7 @@
     <ul class="au-c-list-horizontal">
       {{#if @contactRoute}}
       <li class="au-c-list-horizontal__item">
-        <AuLink @linkRoute="{{@contactRoute}}" @skin="secondary">
+        <AuLink @route="{{@contactRoute}}" @skin="secondary">
           <AuIcon @icon="question-circle" @alignment="left" />
           Contacteer ons
         </AuLink>

--- a/addon/components/au-navigation-link.hbs
+++ b/addon/components/au-navigation-link.hbs
@@ -1,5 +1,5 @@
 <LinkTo
-  @route={{@linkRoute}}
+  @route={{this.route}}
   @models={{au-link-to-models @model @models}}
   class="au-c-list-navigation__link" ...attributes
   {{on "click" this.linkFocus}}

--- a/addon/components/au-navigation-link.js
+++ b/addon/components/au-navigation-link.js
@@ -1,7 +1,30 @@
 import Component from "@glimmer/component";
+import { deprecate } from '@ember/debug';
 import { action } from "@ember/object";
 
 export default class AuNavigationLink extends Component {
+  get route() {
+    if (this.args.linkRoute) {
+      deprecate(
+        '@linkRoute is deprecated, use @route instead',
+        false,
+        {
+          id: '@appuniversum/ember-appuniversum.au-navigation-link.linkRoute-argument',
+          until: "0.7.0",
+          for: '@appuniversum/ember-appuniversum',
+          since: {
+            enabled: '0.5.0'
+          }
+        }
+      );
+
+      return this.args.linkRoute;
+    } else if (this.args.route) {
+      return this.args.route;
+    } else {
+      return undefined;
+    }
+  }
   @action
   linkFocus() {
     // Focus content window

--- a/tests/dummy/app/components/sidebar.hbs
+++ b/tests/dummy/app/components/sidebar.hbs
@@ -12,17 +12,17 @@
           {{nav.section "Outline"}}
           <ul class="au-c-list-navigation">
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.outline.getting-started">
+              <AuNavigationLink @route="docs.outline.getting-started">
                 Getting started
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.outline.webuniversum">
+              <AuNavigationLink @route="docs.outline.webuniversum">
                 Converting from Webuniversum
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.outline.accessibility">
+              <AuNavigationLink @route="docs.outline.accessibility">
                 Accessibility
               </AuNavigationLink>
             </li>
@@ -32,112 +32,112 @@
           {{nav.section "Atoms"}}
           <ul class="au-c-list-navigation">
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-badge">
+              <AuNavigationLink @route="docs.atoms.au-badge">
                 Badge
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-brand">
+              <AuNavigationLink @route="docs.atoms.au-brand">
                 Brand
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-button">
+              <AuNavigationLink @route="docs.atoms.au-button">
                 Button
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-button-group">
+              <AuNavigationLink @route="docs.atoms.au-button-group">
                 Button Group
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-content">
+              <AuNavigationLink @route="docs.atoms.au-content">
                 Content
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-form-label">
+              <AuNavigationLink @route="docs.atoms.au-form-label">
                 Form: Label
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-form-input">
+              <AuNavigationLink @route="docs.atoms.au-form-input">
                 Form: Input
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-form-textarea">
+              <AuNavigationLink @route="docs.atoms.au-form-textarea">
                 Form: Textarea
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-form-datepicker">
+              <AuNavigationLink @route="docs.atoms.au-form-datepicker">
                 Form: Datepicker
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-form-timepicker">
+              <AuNavigationLink @route="docs.atoms.au-form-timepicker">
                 Form: Timepicker
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-form-radio">
+              <AuNavigationLink @route="docs.atoms.au-form-radio">
                 Form: Radio button
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-form-checkbox">
+              <AuNavigationLink @route="docs.atoms.au-form-checkbox">
                 Form: Checkbox
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.ember-power-select">
+              <AuNavigationLink @route="docs.atoms.ember-power-select">
                 Form: ember power select (draft)
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-heading">
+              <AuNavigationLink @route="docs.atoms.au-heading">
                 Heading
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-helptext">
+              <AuNavigationLink @route="docs.atoms.au-helptext">
                 Helptext
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-hr">
+              <AuNavigationLink @route="docs.atoms.au-hr">
                 Horizontal Ruler
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-icon">
+              <AuNavigationLink @route="docs.atoms.au-icon">
                 Icon
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-link">
+              <AuNavigationLink @route="docs.atoms.au-link">
                 Link
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-loader">
+              <AuNavigationLink @route="docs.atoms.au-loader">
                 Loader
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-navigation-link">
+              <AuNavigationLink @route="docs.atoms.au-navigation-link">
                 Navigation link
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-pill">
+              <AuNavigationLink @route="docs.atoms.au-pill">
                 Pill
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.atoms.au-toggle-switch">
+              <AuNavigationLink @route="docs.atoms.au-toggle-switch">
                 Toggle switch
               </AuNavigationLink>
             </li>
@@ -147,32 +147,32 @@
           {{nav.section "Components"}}
           <ul class="au-c-list-navigation">
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.components.au-accordion">
+              <AuNavigationLink @route="docs.components.au-accordion">
                 Accordion
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.components.au-alert">
+              <AuNavigationLink @route="docs.components.au-alert">
                 Alert
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.components.au-card">
+              <AuNavigationLink @route="docs.components.au-card">
                 Card
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.components.au-data-table">
+              <AuNavigationLink @route="docs.components.au-data-table">
                 Data table (draft)
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.components.au-dropdown">
+              <AuNavigationLink @route="docs.components.au-dropdown">
                 Dropdown
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.components.au-modal">
+              <AuNavigationLink @route="docs.components.au-modal">
                 Modal
               </AuNavigationLink>
             </li>
@@ -182,37 +182,37 @@
           {{nav.section "Patterns"}}
           <ul class="au-c-list-navigation">
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.patterns.au-body-container">
+              <AuNavigationLink @route="docs.patterns.au-body-container">
                 Body container
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.patterns.au-content-header">
+              <AuNavigationLink @route="docs.patterns.au-content-header">
                 Content header
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.patterns.au-card-edit">
+              <AuNavigationLink @route="docs.patterns.au-card-edit">
                 Editable card
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.patterns.au-main-container">
+              <AuNavigationLink @route="docs.patterns.au-main-container">
                 Main container
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.patterns.au-main-header">
+              <AuNavigationLink @route="docs.patterns.au-main-header">
                 Main header
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.patterns.au-main-footer">
+              <AuNavigationLink @route="docs.patterns.au-main-footer">
                 Main footer
               </AuNavigationLink>
             </li>
             <li class="au-c-list-navigation__item">
-              <AuNavigationLink @linkRoute="docs.patterns.au-toolbar">
+              <AuNavigationLink @route="docs.patterns.au-toolbar">
                 Toolbar
               </AuNavigationLink>
             </li>

--- a/tests/dummy/app/templates/docs/atoms/au-badge.md
+++ b/tests/dummy/app/templates/docs/atoms/au-badge.md
@@ -51,5 +51,5 @@
 | ------------- | ----------- | ---- | ------------- |
 | `@skin` | Sets the color and background color | `value`: `none` / `border` / `brand` / `success` / `warning` / `error` / `action` | `gray` |
 | `@size` | Change the size of the badge | `value`: `small` | - |
-| `@icon` | Adds an icon to the badge | `value`: <AuLink @linkRoute="docs.atoms.au-icon">Find the options here</AuLink> | - |
+| `@icon` | Adds an icon to the badge | `value`: <AuLink @route="docs.atoms.au-icon">Find the options here</AuLink> | - |
 | `@number` | Adds a number to the badge | `value`: 1 - 100 | - |

--- a/tests/dummy/app/templates/docs/atoms/au-button.md
+++ b/tests/dummy/app/templates/docs/atoms/au-button.md
@@ -107,7 +107,7 @@
 | ------------- | ----------- | ---- | ------------- |
 | `@skin` | Defines the style of the button  | `value`: `primary` / `secondary` / `tertiary` | `primary` |
 | `@size` | Set the size of the button  | `value`: `large` | - |
-| `@icon` | Adds an icon  | `value`: <AuLink @linkRoute="docs.atoms.au-icon">Find the options here</AuLink> | - |
+| `@icon` | Adds an icon  | `value`: <AuLink @route="docs.atoms.au-icon">Find the options here</AuLink> | - |
 | `@iconAlignment` | Choose the position of the icon, adds correct margin next to the icon | `value`: `left` / `right` | - |
 | `@hideText` | Hides the button text visually | `Boolean` | `false` |
 | `@width` | Defines the width of a button | `value`: `block` | - |

--- a/tests/dummy/app/templates/docs/atoms/au-form-input.md
+++ b/tests/dummy/app/templates/docs/atoms/au-form-input.md
@@ -93,5 +93,5 @@
 | ------------- | ----------- | ---- | ------------- |
 | `@error` | Add an error state  | `Boolean` | `false` |
 | `@width` | Display the input as a block element  | `value`: `block` | - |
-| `@icon` | Adds an icon (using an icon implies the use @width="block") | `value`: <AuLink @linkRoute="docs.atoms.au-icon">Find the options here</AuLink> | - |
+| `@icon` | Adds an icon (using an icon implies the use @width="block") | `value`: <AuLink @route="docs.atoms.au-icon">Find the options here</AuLink> | - |
 | `@iconAlignment` | Choose the position of the icon | `value`: `left` / `right`  | `left` |

--- a/tests/dummy/app/templates/docs/atoms/au-link.md
+++ b/tests/dummy/app/templates/docs/atoms/au-link.md
@@ -69,7 +69,7 @@
 
 | Argument      | Description | Type | Default value |
 | ------------- | ----------- | ---- | ------------- |
-| `@linkRoute` | The route that is passed to the link  | `route name` | - |
+| `@route` | The route that is passed to the link  | `route name` | - |
 | `@skin` | Defines the style of the link  | Valid skin options: <br> `primary` / `secondary` / `button` / `button-secondary` | `primary` |
 | `@icon` | Adds an icon  | `value`: <AuLink @linkRoute="docs.atoms.au-icon">Find the options here</AuLink> | - |
 | `@iconAlignment` | Choose the position of the icon, adds correct margin next to the icon | `value`: `left` / `right` | - |

--- a/tests/dummy/app/templates/docs/atoms/au-link.md
+++ b/tests/dummy/app/templates/docs/atoms/au-link.md
@@ -6,13 +6,13 @@
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='au-link-skin.hbs'}}
-    <AuLink @linkRoute="docs.atoms.au-link">
+    <AuLink @route="docs.atoms.au-link">
       Primary link
     </AuLink>
 
     <hr>
 
-    <AuLink @linkRoute="docs.atoms.au-link" @skin="secondary">
+    <AuLink @route="docs.atoms.au-link" @skin="secondary">
       Secondary link
     </AuLink>
 
@@ -35,19 +35,19 @@
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='au-link-icon.hbs'}}
-    <AuLink @linkRoute="docs.atoms.au-link" @icon="login" @iconAlignment="left">
+    <AuLink @route="docs.atoms.au-link" @icon="login" @iconAlignment="left">
       Primary link + icon (left)
     </AuLink>
 
     <hr>
 
-    <AuLink @linkRoute="docs.atoms.au-link" @icon="login" @iconAlignment="right">
+    <AuLink @route="docs.atoms.au-link" @icon="login" @iconAlignment="right">
       Primary link + icon (right)
     </AuLink>
 
     <hr>
 
-    <AuLink @linkRoute="docs.atoms.au-link" @icon="login" @hideText={{true}}>
+    <AuLink @route="docs.atoms.au-link" @icon="login" @hideText={{true}}>
       Primary link + icon
     </AuLink>
   {{/demo.example}}
@@ -58,7 +58,7 @@
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='au-link-active.hbs'}}
-    <AuLink @linkRoute="docs.atoms.au-link" @active={{true}}>
+    <AuLink @route="docs.atoms.au-link" @active={{true}}>
       Primary link - active
     </AuLink>
   {{/demo.example}}
@@ -71,7 +71,7 @@
 | ------------- | ----------- | ---- | ------------- |
 | `@route` | The route that is passed to the link  | `route name` | - |
 | `@skin` | Defines the style of the link  | Valid skin options: <br> `primary` / `secondary` / `button` / `button-secondary` | `primary` |
-| `@icon` | Adds an icon  | `value`: <AuLink @linkRoute="docs.atoms.au-icon">Find the options here</AuLink> | - |
+| `@icon` | Adds an icon  | `value`: <AuLink @route="docs.atoms.au-icon">Find the options here</AuLink> | - |
 | `@iconAlignment` | Choose the position of the icon, adds correct margin next to the icon | `value`: `left` / `right` | - |
 | `@hideText` | Hides the link text visually | `Boolean` | `false` |
 | `@active` | Adds an active state and disables pointer events | `Boolean` | `false` |

--- a/tests/dummy/app/templates/docs/atoms/au-navigation-link.md
+++ b/tests/dummy/app/templates/docs/atoms/au-navigation-link.md
@@ -24,5 +24,5 @@
 
 | Argument      | Description | Type | Default value |
 | ------------- | ----------- | ---- | ------------- |
-| `@linkRoute` | The route that is passed to the link  | `route name` | - |
+| `@route` | The route that is passed to the link  | `route name` | - |
 | `@model` / `@models` | [Supply a model to the route](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/input?anchor=LinkTo#supplying-a-model) | `route model(s)` | - |

--- a/tests/dummy/app/templates/docs/atoms/au-navigation-link.md
+++ b/tests/dummy/app/templates/docs/atoms/au-navigation-link.md
@@ -6,12 +6,12 @@
   {{#demo.example name='au-navigation-link.hbs'}}
     <ul class="au-c-list-navigation">
       <li class="au-c-list-navigation__item">
-        <AuNavigationLink @linkRoute="docs.atoms.au-button">
+        <AuNavigationLink @route="docs.atoms.au-button">
           Navigation link
         </AuNavigationLink>
       </li>
       <li class="au-c-list-navigation__item">
-        <AuNavigationLink @linkRoute="docs.atoms.au-navigation-link">
+        <AuNavigationLink @route="docs.atoms.au-navigation-link">
           Navigation link active
         </AuNavigationLink>
       </li>

--- a/tests/dummy/app/templates/docs/atoms/au-pill.md
+++ b/tests/dummy/app/templates/docs/atoms/au-pill.md
@@ -63,5 +63,5 @@
 | Argument      | Description | Type | Default value |
 | ------------- | ----------- | ---- | ------------- |
 | `@skin` | Sets the style of the badge  | `value`: `default` / `border` / `action` / `success` / `warning` / `error` | `default` |
-| `@icon` | Adds an icon  | `value`: <AuLink @linkRoute="docs.atoms.au-icon">Find the options here</AuLink> | - |
+| `@icon` | Adds an icon  | `value`: <AuLink @route="docs.atoms.au-icon">Find the options here</AuLink> | - |
 | `@iconAlignment` | Choose the position of the icon, adds correct margin next to the icon | `value`: `left` / `right` | - |

--- a/tests/dummy/app/templates/docs/components/au-accordion.md
+++ b/tests/dummy/app/templates/docs/components/au-accordion.md
@@ -34,8 +34,8 @@
 ## Accordion Arguments
 | Argument      | Description | Type | Default value |
 | ------------- | ----------- | ---- | ------------- |
-| `@accordionIconOpen` | Adds an icon to the accordion when it's open | `value`: <AuLink @linkRoute="docs.atoms.au-icon">Find the options here</AuLink> | - |
-| `@accordionIconClosed` | Adds an icon to the accordion when it's open | `value`: <AuLink @linkRoute="docs.atoms.au-icon">Find the options here</AuLink> | - |
+| `@accordionIconOpen` | Adds an icon to the accordion when it's open | `value`: <AuLink @route="docs.atoms.au-icon">Find the options here</AuLink> | - |
+| `@accordionIconClosed` | Adds an icon to the accordion when it's open | `value`: <AuLink @route="docs.atoms.au-icon">Find the options here</AuLink> | - |
 | `@accordionButtonLabel` | Set the label of the button | `String` | - |
 | `@accordionSubTitle` | Set the subtitle of the accordion | `String` | - |
 | `@loading` | Adds a loading state to the button | `Boolean` | `false` |

--- a/tests/dummy/app/templates/docs/components/au-alert.md
+++ b/tests/dummy/app/templates/docs/components/au-alert.md
@@ -102,7 +102,7 @@
 | Argument      | Description | Type | Default value |
 | ------------- | ----------- | ---- | ------------- |
 | `@alertSkin` | Sets the style of the alert  | `value`: `info` / `success` / `warning` / `error` | - |
-| `@alertIcon` | Add an icon to the alert | `value`: <AuLink @linkRoute="docs.atoms.au-icon">Find the options here</AuLink> | - |
+| `@alertIcon` | Add an icon to the alert | `value`: <AuLink @route="docs.atoms.au-icon">Find the options here</AuLink> | - |
 | `@alertSize` | Set the size of the alert | `value`: `small` / `default` | `default` |
 | `@alertTitle` | Add a title to the alert | `String` | - |
 | `@closable` | Makes the alert closable | `Boolean` | `false` |

--- a/tests/dummy/app/templates/docs/components/au-card.md
+++ b/tests/dummy/app/templates/docs/components/au-card.md
@@ -216,6 +216,6 @@
 
 | Argument      | Description | Type | Default value |
 | ------------- | ----------- | ---- | ------------- |
-| `@badgeIcon` | Add an icon  | `value`: <AuLink @linkRoute="docs.atoms.au-icon">Find the options here</AuLink> | - |
+| `@badgeIcon` | Add an icon  | `value`: <AuLink @route="docs.atoms.au-icon">Find the options here</AuLink> | - |
 | `@badgeSkin` | Set the theme of the badge  | `value`: `none` / `border` / `brand` / `success` / `warning` / `error` / `action` | `none` |
 | `@badgeSize` | Set the size of the badge  | `value`: `small` / `default` | `default` |

--- a/tests/dummy/app/templates/docs/outline/webuniversum.md
+++ b/tests/dummy/app/templates/docs/outline/webuniversum.md
@@ -10,41 +10,41 @@ Most of the components from Webuniversum are available in Appuniversum. The curr
 
 | Webuniversum      | Appuniversum | Status | 
 | ------------- | ----------- | ---- | 
-| `wu-alert` | <AuLink @linkRoute="docs.components.au-alert">AuAlert</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-accordion` | Use <AuLink @linkRoute="docs.components.au-card">AuCard</AuLink> instead | <AuPill @skin="success">Available</AuPill> |
-| `wu-badge` | <AuLink @linkRoute="docs.atoms.au-badge">AuBadge</AuLink>  | <AuPill @skin="success">Available</AuPill> |
-| `wu-button` | <AuLink @linkRoute="docs.atoms.au-button">AuButton</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-button-group` | <AuLink @linkRoute="docs.atoms.au-button-group">AuButtonGroup</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-content-header` | <AuLink @linkRoute="docs.patterns.au-content-header">AuContentHeader</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-datepicker` | <AuLink @linkRoute="docs.atoms.au-form-datepicker">AuDatepicker</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-icon` | <AuLink @linkRoute="docs.atoms.au-icon">AuIcon</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-link-button` | Replaced by <AuLink @linkRoute="docs.atoms.au-link">AuLink</AuLink> or <AuLink @linkRoute="docs.atoms.au-button">AuButton</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-loader` | <AuLink @linkRoute="docs.atoms.au-loader">AuLoader</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-modal` | <AuLink @linkRoute="docs.components.au-modal">AuModal</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-pill` | <AuLink @linkRoute="docs.atoms.au-pill">AuPill</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-popover` | <AuLink @linkRoute="docs.components.au-dropdown">Dropdown</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-radio-button` | <AuLink @linkRoute="docs.atoms.au-form-radio">AuControlRadio</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-switch` | <AuLink @linkRoute="docs.atoms.au-toggle-switch">AuToggleSwitch</AuLink> | <AuPill @skin="success">Available</AuPill> |
-| `wu-checkbox` | <AuLink @linkRoute="docs.atoms.au-form-checkbox">AuControlCheckbox</AuLink> | <AuPill>In progress</AuPill> |
-| `data-table` | <AuLink @linkRoute="docs.components.au-data-table">AuDataTable</AuLink> | <AuPill>In progress</AuPill> |
-| `power-select` | <AuLink @linkRoute="docs.atoms.ember-power-select">PowerSelect</AuLink> | <AuPill>In progress</AuPill> |
-| - | <AuLink @linkRoute="docs.patterns.au-body-container">AuBodyContainer</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.atoms.au-brand">AuBrand</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.atoms.au-content">AuContent</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.components.au-card">AuCard</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.atoms.au-form-input">AuInput</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.atoms.au-heading">AuHeading</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.atoms.au-helptext">AuHelptext</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.atoms.au-hr">AuHr</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.atoms.au-form-label">AuLabel</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.atoms.au-link">AuLink</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.patterns.au-main-container">AuMainContainer</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.patterns.au-main-header">AuMainHeader</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.patterns.au-main-footer">AuMainfooter</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.atoms.au-navigation-link">AuNavigationLink</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.atoms.au-form-timepicker">AuTimepicker</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.atoms.au-form-textarea">AuTextarea</AuLink> | <AuPill @skin="action">New</AuPill> |
-| - | <AuLink @linkRoute="docs.patterns.au-toolbar">AuToolbar</AuLink> | <AuPill @skin="action">New</AuPill> |
+| `wu-alert` | <AuLink @route="docs.components.au-alert">AuAlert</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-accordion` | Use <AuLink @route="docs.components.au-card">AuCard</AuLink> instead | <AuPill @skin="success">Available</AuPill> |
+| `wu-badge` | <AuLink @route="docs.atoms.au-badge">AuBadge</AuLink>  | <AuPill @skin="success">Available</AuPill> |
+| `wu-button` | <AuLink @route="docs.atoms.au-button">AuButton</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-button-group` | <AuLink @route="docs.atoms.au-button-group">AuButtonGroup</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-content-header` | <AuLink @route="docs.patterns.au-content-header">AuContentHeader</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-datepicker` | <AuLink @route="docs.atoms.au-form-datepicker">AuDatepicker</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-icon` | <AuLink @route="docs.atoms.au-icon">AuIcon</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-link-button` | Replaced by <AuLink @route="docs.atoms.au-link">AuLink</AuLink> or <AuLink @route="docs.atoms.au-button">AuButton</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-loader` | <AuLink @route="docs.atoms.au-loader">AuLoader</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-modal` | <AuLink @route="docs.components.au-modal">AuModal</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-pill` | <AuLink @route="docs.atoms.au-pill">AuPill</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-popover` | <AuLink @route="docs.components.au-dropdown">Dropdown</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-radio-button` | <AuLink @route="docs.atoms.au-form-radio">AuControlRadio</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-switch` | <AuLink @route="docs.atoms.au-toggle-switch">AuToggleSwitch</AuLink> | <AuPill @skin="success">Available</AuPill> |
+| `wu-checkbox` | <AuLink @route="docs.atoms.au-form-checkbox">AuControlCheckbox</AuLink> | <AuPill>In progress</AuPill> |
+| `data-table` | <AuLink @route="docs.components.au-data-table">AuDataTable</AuLink> | <AuPill>In progress</AuPill> |
+| `power-select` | <AuLink @route="docs.atoms.ember-power-select">PowerSelect</AuLink> | <AuPill>In progress</AuPill> |
+| - | <AuLink @route="docs.patterns.au-body-container">AuBodyContainer</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.atoms.au-brand">AuBrand</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.atoms.au-content">AuContent</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.components.au-card">AuCard</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.atoms.au-form-input">AuInput</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.atoms.au-heading">AuHeading</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.atoms.au-helptext">AuHelptext</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.atoms.au-hr">AuHr</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.atoms.au-form-label">AuLabel</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.atoms.au-link">AuLink</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.patterns.au-main-container">AuMainContainer</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.patterns.au-main-header">AuMainHeader</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.patterns.au-main-footer">AuMainfooter</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.atoms.au-navigation-link">AuNavigationLink</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.atoms.au-form-timepicker">AuTimepicker</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.atoms.au-form-textarea">AuTextarea</AuLink> | <AuPill @skin="action">New</AuPill> |
+| - | <AuLink @route="docs.patterns.au-toolbar">AuToolbar</AuLink> | <AuPill @skin="action">New</AuPill> |
 | `wu-contact-card` | - | <AuPill @skin="warning">Not started</AuPill> |
 | `wu-date-range` | - | <AuPill @skin="warning">Not started</AuPill> |
 | `wu-document-miniature` | - | <AuPill @skin="warning">Not started</AuPill> |

--- a/tests/dummy/app/templates/docs/patterns/au-card-edit.md
+++ b/tests/dummy/app/templates/docs/patterns/au-card-edit.md
@@ -104,6 +104,6 @@
 
 | Argument      | Description | Type | Default value |
 | ------------- | ----------- | ---- | ------------- |
-| `@badgeIcon` | Add an icon  | `value`: <AuLink @linkRoute="docs.atoms.au-icon">Find the options here</AuLink> | - |
+| `@badgeIcon` | Add an icon  | `value`: <AuLink @route="docs.atoms.au-icon">Find the options here</AuLink> | - |
 | `@badgeSkin` | Set the theme of the badge  | `value`: `none` / `border` / `brand` / `success` / `warning` / `error` / `action` | `none` |
 | `@badgeSize` | Set the size of the badge  | `value`: `small` / `default` | `default` |

--- a/tests/dummy/app/templates/docs/patterns/au-main-footer.md
+++ b/tests/dummy/app/templates/docs/patterns/au-main-footer.md
@@ -12,10 +12,10 @@
         <p>Uitgegeven door <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">Agentschap Binnenlands Bestuur</a></p>
         <ul class="au-c-list-horizontal">
           <li class="au-c-list-horizontal__item">
-            <AuLink @linkRoute="index" @skin="secondary">Disclaimer</AuLink>
+            <AuLink @route="index" @skin="secondary">Disclaimer</AuLink>
           </li>
           <li class="au-c-list-horizontal__item">
-            <AuLink @linkRoute="index" @skin="secondary">Cookieverklaring</AuLink>
+            <AuLink @route="index" @skin="secondary">Cookieverklaring</AuLink>
           </li>
         </ul>
       </AuContent>

--- a/tests/dummy/app/templates/docs/patterns/au-toolbar.md
+++ b/tests/dummy/app/templates/docs/patterns/au-toolbar.md
@@ -18,7 +18,7 @@
         </AuButtonGroup>
       </AuToolbarGroup>
       <AuToolbarGroup>
-        <AuLink @linkRoute="docs.patterns.au-toolbar" @skin="secondary">
+        <AuLink @route="docs.patterns.au-toolbar" @skin="secondary">
           Secondary link
         </AuLink>
       </AuToolbarGroup>
@@ -63,7 +63,7 @@
         </AuButtonGroup>
       </AuToolbarGroup>
       <AuToolbarGroup>
-        <AuLink @linkRoute="docs.patterns.au-toolbar" @skin="secondary">
+        <AuLink @route="docs.patterns.au-toolbar" @skin="secondary">
           Secondary link
         </AuLink>
       </AuToolbarGroup>
@@ -88,7 +88,7 @@
         </AuButtonGroup>
       </AuToolbarGroup>
       <AuToolbarGroup>
-        <AuLink @linkRoute="docs.patterns.au-toolbar" @skin="secondary">
+        <AuLink @route="docs.patterns.au-toolbar" @skin="secondary">
           Secondary link
         </AuLink>
       </AuToolbarGroup>
@@ -113,7 +113,7 @@
         </AuButtonGroup>
       </AuToolbarGroup>
       <AuToolbarGroup>
-        <AuLink @linkRoute="docs.patterns.au-toolbar" @skin="secondary">
+        <AuLink @route="docs.patterns.au-toolbar" @skin="secondary">
           Secondary link
         </AuLink>
       </AuToolbarGroup>
@@ -138,7 +138,7 @@
         </AuButtonGroup>
       </AuToolbarGroup>
       <AuToolbarGroup>
-        <AuLink @linkRoute="docs.patterns.au-toolbar" @skin="secondary">
+        <AuLink @route="docs.patterns.au-toolbar" @skin="secondary">
           Secondary link
         </AuLink>
       </AuToolbarGroup>
@@ -155,7 +155,7 @@
         </AuButtonGroup>
       </AuToolbarGroup>
       <AuToolbarGroup>
-        <AuLink @linkRoute="docs.patterns.au-toolbar" @skin="secondary">
+        <AuLink @route="docs.patterns.au-toolbar" @skin="secondary">
           Secondary link
         </AuLink>
       </AuToolbarGroup>
@@ -172,7 +172,7 @@
         </AuButtonGroup>
       </AuToolbarGroup>
       <AuToolbarGroup>
-        <AuLink @linkRoute="docs.patterns.au-toolbar" @skin="secondary">
+        <AuLink @route="docs.patterns.au-toolbar" @skin="secondary">
           Secondary link
         </AuLink>
       </AuToolbarGroup>


### PR DESCRIPTION
[As mentioned before](https://github.com/appuniversum/ember-appuniversum/issues/88#issuecomment-844026558) I think `@route` is a better and more intuitive name for that argument since that's what `<LinkTo>` uses.

Not a breaking change since `@linkRoute` still works (but it will show a deprecation).