### PR TITLE
Add a total row fallback to the data table component

### DIFF
--- a/addon/components/au-data-table/number-pagination.hbs
+++ b/addon/components/au-data-table/number-pagination.hbs
@@ -1,6 +1,6 @@
 <div class="au-c-pagination">
   <p>
-    <span class="au-u-hidden-visually">Rij </span><strong>{{startItem}} - {{endItem}}</strong> van {{total}}
+    <span class="au-u-hidden-visually">Rij </span><strong>{{this.startItem}} - {{this.endItem}}</strong> van {{this.totalItems}}
   </p>
   <ul class="au-c-pagination__list">
     {{#if hasMultiplePages}}

--- a/addon/components/au-data-table/number-pagination.js
+++ b/addon/components/au-data-table/number-pagination.js
@@ -1,5 +1,10 @@
 import NumberPagination from 'ember-data-table/components/number-pagination';
+import { computed } from '@ember/object';
 
 export default NumberPagination.extend({
-  tagName: ''
+  tagName: '',
+
+  totalItems: computed('total', 'nbOfItems', function() {
+    return this.total ? this.total : this.nbOfItems;
+  })
 });

--- a/tests/dummy/app/templates/docs/components/au-data-table.md
+++ b/tests/dummy/app/templates/docs/components/au-data-table.md
@@ -45,7 +45,7 @@ Wrapper for [https://github.com/mu-semtech/ember-data-table](https://github.com/
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='au-data-table-small.hbs'}}
-    <AuDataTable @content={{this.model}} @fields="title description" @noDataMessage="Geen documenten" @sort={{sort}} @size="small" as |t|>
+    <AuDataTable @content={{this.model}} @fields="title description" @noDataMessage="Geen documenten" @sort={{sort}} as |t|>
       <t.menu as |menu|>
         <menu.general>
           <AuToolbar class="au-o-box">
@@ -80,4 +80,4 @@ Wrapper for [https://github.com/mu-semtech/ember-data-table](https://github.com/
 
 ## Arguments
 
-- For now, you can only add the class [au-c-data-table__table--small] in the content tag.
+- For now, you can only add the class `au-c-data-table__table--small` in the content tag.


### PR DESCRIPTION
This shows the total number of visible rows when the pagination meta object doesn't include a count. This means that arrays that are created client side are supported as well.

Closes #136 