### PR TITLE
Timepicker improvements (added arguments, octane upgrade & minor tweaks)

### DIFF
--- a/addon/components/au-time-picker.hbs
+++ b/addon/components/au-time-picker.hbs
@@ -2,7 +2,7 @@
   <div class="au-time-picker__box">
     <AuLabel for="input-hour">{{@hoursLabel}}</AuLabel>
     <div class="au-time-picker__input-wrapper">
-      <AuInput class="au-time-picker__input" value={{format-time this.hourValue}} name="input-hour" id="input-hour"
+      <AuInput class="au-time-picker__input" value={{format-time-digit this.hourValue}} name="input-hour" id="input-hour"
         {{on 'keyup' (fn this.setTimeValue "hourValue")}}
         {{on 'focusout' (fn this.updateTime "hourValue")}}
       />
@@ -18,7 +18,7 @@
   <div class="au-time-picker__box">
     <AuLabel for="input-minute">{{@minutesLabel}}</AuLabel>
     <div class="au-time-picker__input-wrapper">
-      <AuInput class="au-time-picker__input" value={{format-time this.minuteValue}} name="input-minute" id="input-minute"
+      <AuInput class="au-time-picker__input" value={{format-time-digit this.minuteValue}} name="input-minute" id="input-minute"
         {{on 'keyup' (fn this.setTimeValue "minuteValue")}}
         {{on 'focusout' (fn this.updateTime "minuteValue")}}
       />
@@ -35,7 +35,7 @@
     <div class="au-time-picker__box">
       <AuLabel for="input-second">{{@secondsLabel}}</AuLabel>
       <div class="au-time-picker__input-wrapper">
-        <AuInput class="au-time-picker__input" value={{format-time this.secondValue}} name="input-second" id="input-second"
+        <AuInput class="au-time-picker__input" value={{format-time-digit this.secondValue}} name="input-second" id="input-second"
           {{on 'keyup' (fn this.setTimeValue "secondValue")}}
           {{on 'focusout' (fn this.updateTime "secondValue")}}
         />

--- a/addon/components/au-time-picker.hbs
+++ b/addon/components/au-time-picker.hbs
@@ -29,26 +29,31 @@
     </div>
   </div>
 
-  <span class="au-time-picker__separator">:</span>
+  {{#if this.showSeconds}}
+    <span class="au-time-picker__separator">:</span>
 
-  <div class="au-time-picker__box">
-    <AuLabel for="input-second">{{@secondsLabel}}</AuLabel>
-    <div class="au-time-picker__input-wrapper">
-      <AuInput class="au-time-picker__input" value={{format-time this.secondValue}} name="input-second" id="input-second"
-        {{on 'keyup' (fn this.setTimeValue "secondValue")}}
-        {{on 'focusout' (fn this.updateTime "secondValue")}}
-      />
-      <div class="au-time-picker__button-wrapper">
-        <button aria-label="increment seconds" {{on 'click' (fn this.increment "secondValue")}} type="button" aria-controls="input-second" class="au-time-picker__button">+</button>
-        <button aria-label="decrement seconds" {{on 'click' (fn this.decrement "secondValue")}} type="button" aria-controls="input-second" class="au-time-picker__button">-</button>
+    <div class="au-time-picker__box">
+      <AuLabel for="input-second">{{@secondsLabel}}</AuLabel>
+      <div class="au-time-picker__input-wrapper">
+        <AuInput class="au-time-picker__input" value={{format-time this.secondValue}} name="input-second" id="input-second"
+          {{on 'keyup' (fn this.setTimeValue "secondValue")}}
+          {{on 'focusout' (fn this.updateTime "secondValue")}}
+        />
+        <div class="au-time-picker__button-wrapper">
+          <button aria-label="increment seconds" {{on 'click' (fn this.increment "secondValue")}} type="button" aria-controls="input-second" class="au-time-picker__button">+</button>
+          <button aria-label="decrement seconds" {{on 'click' (fn this.decrement "secondValue")}} type="button" aria-controls="input-second" class="au-time-picker__button">-</button>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="au-time-picker__box">
-    <AuButton class="au-time-picker__current" {{on 'click' this.setCurrentTime}}>
-      {{@nowLabel}}
-    </AuButton>
-  </div>
+  {{/if}}
+
+  {{#if this.showNow}}
+    <div class="au-time-picker__box">
+      <AuButton class="au-time-picker__current" {{on 'click' this.setCurrentTime}}>
+        {{@nowLabel}}
+      </AuButton>
+    </div>
+  {{/if}}
 
   <span class="au-u-hidden-visually">{{this.hourValue}} {{@hoursLabel}}, {{this.minuteValue}} {{@minutesLabel}}, {{this.secondValue}} {{@secondsLabel}}.</span>
 </div>

--- a/addon/components/au-time-picker.js
+++ b/addon/components/au-time-picker.js
@@ -1,11 +1,12 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { isPresent } from '@ember/utils';
 
 export default class AuTimePickerComponent extends Component {
-  @tracked hourValue = this.hours || 12;
-  @tracked minuteValue = this.minutes || 0;
-  @tracked secondValue = this.seconds || 0;
+  @tracked hourValue = this.args.hours || 12;
+  @tracked minuteValue = this.args.minutes || 0;
+  @tracked secondValue = (isPresent(this.args.showSeconds) && !this.args.showSeconds) ? 0 : this.args.seconds || 0; // ignore 'seconds' argument if 'showSeconds' is false
   @tracked keyCodes = [ 8 , 9, 13 , 33 , 34 , 37 , 39, 46 ];
 
   get getTimeObject(){
@@ -16,10 +17,18 @@ export default class AuTimePickerComponent extends Component {
     };
   }
 
+  get showSeconds() {
+    return isPresent(this.args.showSeconds) ? this.args.showSeconds : true;
+  }
+
+  get showNow() {
+    return isPresent(this.args.showNow) ? this.args.showNow : true;
+  }
+
   /*
    * Increments or decrements a time value.
-   * HourValue has a max of 24 while minute & seconds have a max of 60
-   * HourValue has a min of 1 while minute  seconds have a min of 0
+   * HourValue has a max of 23 while minute & seconds have a max of 59
+   * HourValue, minute & seconds have a min of 0
    */
 
   @action
@@ -27,16 +36,16 @@ export default class AuTimePickerComponent extends Component {
     if (elem == 'hourValue') {
       ++this[elem];
 
-      if (this[elem] >= 24) {
-        this[elem] = 24;
+      if (this[elem] >= 23) {
+        this[elem] = 23;
       }
     }
 
     if (elem != 'hourValue') {
       ++this[elem];
 
-      if (this[elem] >= 60) {
-        this[elem] = 60;
+      if (this[elem] >= 59) {
+        this[elem] = 59;
       }
     }
     this.callBackParent(this.getTimeObject);
@@ -45,20 +54,10 @@ export default class AuTimePickerComponent extends Component {
 
   @action
   decrement(elem){
-    if (elem == 'hourValue') {
-      --this[elem];
+    --this[elem];
 
-      if (this[elem] <= 1) {
-        this[elem] = 1;
-      }
-    }
-
-    if(elem != 'hourValue'){
-      --this[elem];
-
-      if(this[elem] <= 0){
-        this[elem] = 0;
-      }
+    if(this[elem] <= 0){
+      this[elem] = 0;
     }
     this.callBackParent(this.getTimeObject);
   }
@@ -88,7 +87,7 @@ export default class AuTimePickerComponent extends Component {
   }
 
   /*
-   * triggered after focussing out of field. Checks if the inputted value makes sense. (e.g. hour range: 1 - 24)
+   * triggered after focussing out of field. Checks if the inputted value makes sense. (e.g. hour range: 1 - 23)
    * "elem" is the name of the tracked property
    * "e" is the context
    */
@@ -99,8 +98,8 @@ export default class AuTimePickerComponent extends Component {
     if (elem == 'hourValue') {
       if (inputValue < 0) {
         this[elem] = 0;
-      } else if (inputValue > 24) {
-        this[elem] = 24;
+      } else if (inputValue > 23) {
+        this[elem] = 23;
       } else {
         this[elem] = inputValue;
       }
@@ -109,8 +108,8 @@ export default class AuTimePickerComponent extends Component {
     if(elem != 'hourValue'){
       if(inputValue < 0){
         this[elem] = 0;
-      } else if (inputValue > 60) {
-        this[elem] = 60;
+      } else if (inputValue > 59) {
+        this[elem] = 59;
       } else {
         this[elem] = inputValue;
       }
@@ -124,8 +123,8 @@ export default class AuTimePickerComponent extends Component {
 
   @action
   callBackParent(value){
-    if(this.onChange != undefined){
-      this.onChange(value);
+    if(this.args.onChange != undefined){
+      this.args.onChange(value);
     }
   }
 

--- a/addon/helpers/format-time-digit.js
+++ b/addon/helpers/format-time-digit.js
@@ -1,6 +1,6 @@
 import { helper } from '@ember/component/helper';
 
-export default helper(function formatTime([digit]) {
+export default helper(function formatTimeDigit([digit]) {
   if(!isNaN(digit)){
     if(digit.toString().length <= 1){
       return `0${digit}`

--- a/app/helpers/format-time-digit.js
+++ b/app/helpers/format-time-digit.js
@@ -1,0 +1,1 @@
+export { default } from '@appuniversum/ember-appuniversum/helpers/format-time-digit';

--- a/app/helpers/format-time.js
+++ b/app/helpers/format-time.js
@@ -1,1 +1,0 @@
-export { default } from '@appuniversum/ember-appuniversum/helpers/format-time';

--- a/tests/dummy/app/templates/docs/atoms/au-form-datepicker-demo/on-change.js
+++ b/tests/dummy/app/templates/docs/atoms/au-form-datepicker-demo/on-change.js
@@ -1,6 +1,6 @@
 
 /* eslint-disable no-dupe-class-members */
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { action } from "@ember/object";
 
 export default class onChangeSnippets extends Component {

--- a/tests/dummy/app/templates/docs/atoms/au-form-timepicker.md
+++ b/tests/dummy/app/templates/docs/atoms/au-form-timepicker.md
@@ -20,6 +20,24 @@
   {{demo.snippet 'au-dateTime-picker-value.hbs'}}
 {{/docs-demo}}
 
+## Hidden seconds input
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name='au-dateTime-picker-hidden-seconds-input.hbs'}}
+    <AuTimePicker @hours="8" @minutes="12" @showSeconds={{false}} @nowLabel="Now" />
+  {{/demo.example}}
+  {{demo.snippet 'au-dateTime-picker-hidden-seconds-input.hbs'}}
+{{/docs-demo}}
+
+## Hidden now button
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name='au-dateTime-picker-hidden-now-button.hbs'}}
+    <AuTimePicker @hours="17" @minutes="48" @seconds="12" @showNow={{false}} />
+  {{/demo.example}}
+  {{demo.snippet 'au-dateTime-picker-hidden-now-button.hbs'}}
+{{/docs-demo}}
+
 ## @onChange
 
 Triggered everytime the time gets changed by the user. Expects a function to which it returns the time.
@@ -39,10 +57,9 @@ Triggered everytime the time gets changed by the user. Expects a function to whi
 | `@minutesLabel` | Minutes label  | `string` | - |
 | `@secondsLabel` | Seconds label  | `string` | - |
 | `@nowLabel` | Current time button label  | `string` | - |
-| `@nowLabel` | Current time button label  | `string` | - |
-| `@hours`| Sets the hour value | 'integer' | 12 |
-| `@minutes`| Sets the minutes value | 'integer' | 0 |
-| `@seconds`| Sets the seconds value | 'integer' | 0 |
-| `@onChange`| Gets called when a time value changes. Returns an object with all time values in an object | 'object' | - |
-
-
+| `@hours`| Sets the hour value | `integer` | 12 |
+| `@minutes`| Sets the minutes value | `integer` | 0 |
+| `@seconds`| Sets the seconds value | `integer` | 0 |
+| `@showSeconds`| Wether the seconds input is shown | `boolean` | true |
+| `@showNow`| Wether the now button is shown | `boolean` | true |
+| `@onChange`| Gets called when a time value changes. Returns an object with all time values in an object | `object` | - |

--- a/tests/integration/helpers/format-time-test.js
+++ b/tests/integration/helpers/format-time-test.js
@@ -3,14 +3,14 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module('Integration | Helper | format-time', function(hooks) {
+module('Integration | Helper | format-time-digit', function(hooks) {
   setupRenderingTest(hooks);
 
   // Replace this with your real tests.
   test('it renders', async function(assert) {
     this.set('inputValue', '1234');
 
-    await render(hbs`{{format-time inputValue}}`);
+    await render(hbs`{{format-time-digit inputValue}}`);
 
     assert.dom(this.element).hasText('1234');
   });


### PR DESCRIPTION
This PR includes the following adjustments:
- Added `showSeconds` argument: hides/shows the seconds input
- Added `showNow` argument: hides/shows the now button
- Upgraded the component to Octane
- Corrected the min/max values of hours, minutes & seconds
- Renamed the `format-time` helper to avoid conflicts with other libraries/plugins (for example `ember-intl`)
- Adjusted component documentation

Feedback is more then welcome!