### PR TITLE
Fix/easy install

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,23 @@ module.exports = {
       plugins: [require.resolve('ember-auto-import/babel-plugin')],
     },
   },
-  contentFor: function(type /*, config */) {
+
+  included: function (app) {
+    this._super.included.apply(this, arguments);
+
+    app.options.sassOptions = app.options.sassOptions || {};
+    app.options.sassOptions.includePaths =
+      app.options.sassOptions.includePaths || [];
+
+    app.options.sassOptions.includePaths.push(
+      'node_modules/@appuniversum/appuniversum'
+    );
+    app.options.sassOptions.includePaths.push(
+      'node_modules/@appuniversum/ember-appuniversum/app/styles'
+    );
+  },
+
+  contentFor: function(type, config) {
     if (type === 'body'){
       return '<div id="ember-appuniversum-wormhole"></div>';
     } else {

--- a/index.js
+++ b/index.js
@@ -19,9 +19,6 @@ module.exports = {
     app.options.sassOptions.includePaths.push(
       'node_modules/@appuniversum/appuniversum'
     );
-    app.options.sassOptions.includePaths.push(
-      'node_modules/@appuniversum/ember-appuniversum/app/styles'
-    );
   },
 
   contentFor: function(type, config) {


### PR DESCRIPTION
Removes the need to add anything to sass `includePaths` in the consuming app
also removes the need for the consuming app to depend on `@appuniversum/appuniversum`

Consuming apps can simply `@import ember-appuniversum;` in their `app.scss`.
ATTENTION: while the app can import partials as normal, it can of course only import the ember-appuniversum partials, which don't seem to be designed for re-export at the moment. 
If partial importing is desired, I'd recommend to allow for per-component importing, meaning that the host-app can simply one single component partial without having to worry about any global variables and such. Not sure if that's possible with sass, and not sure if it even matters.