### PR TITLE
Cancel workflows when they become outdated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   NODE_VERSION: '12.x'
 


### PR DESCRIPTION
This change ensures that workflows are canceled when new changes come in which means resources aren't wasted on outdated workflows.

More information: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency