### PR TITLE
Add named block support to the `AuModal` component

### DIFF
--- a/addon/components/au-modal-body.hbs
+++ b/addon/components/au-modal-body.hbs
@@ -1,3 +1,3 @@
-<div class="au-c-modal__body">
+<div class="au-c-modal__body" data-test-modal-body>
   {{yield}}
 </div>

--- a/addon/components/au-modal-footer.hbs
+++ b/addon/components/au-modal-footer.hbs
@@ -1,3 +1,3 @@
-<div class="au-c-modal__footer">
+<div class="au-c-modal__footer" data-test-modal-footer>
   {{yield}}
 </div>

--- a/addon/components/au-modal.hbs
+++ b/addon/components/au-modal.hbs
@@ -16,16 +16,21 @@
               allowOutsideClick=true
             )
       }}
+      data-test-modal
       ...attributes
     >
-      <div class="au-c-modal__header">
-        <h1 id="au-c-modal-title-{{@id}}" class="au-c-modal__title" tabindex="-1">
-          {{this.title}}
+      <div class="au-c-modal__header" data-test-modal-header>
+        <h1 id="au-c-modal-title-{{@id}}" class="au-c-modal__title" tabindex="-1" data-test-modal-title>
+          {{#if (has-block "title")}}
+            {{yield to="title"}}
+          {{else}}
+            {{this.title}}
+          {{/if}}
         </h1>
         <button
           class="au-c-modal__close"
           type="button"
-          data-test-au-modal-close
+          data-test-modal-close
           {{on "click" this.closeModal}}
         >
           <AuIcon @icon="cross" @size="large" />
@@ -33,9 +38,27 @@
         </button>
       </div>
 
-      {{yield (hash
-          Body=(component "au-modal-body")
-          Footer=(component "au-modal-footer"))}}
+      {{#if (or
+        (has-block "title")
+        (has-block "body")
+        (has-block "footer")
+      )}}
+        {{#if (has-block "body")}}
+          <div class="au-c-modal__body" data-test-modal-body>
+            {{yield to="body"}}
+          </div>
+        {{/if}}
+
+        {{#if (has-block "footer")}}
+          <div class="au-c-modal__footer" data-test-modal-footer>
+            {{yield to="footer"}}
+          </div>
+        {{/if}}
+      {{else}}
+        {{yield (hash
+            Body=(component "au-modal-body")
+            Footer=(component "au-modal-footer"))}}
+      {{/if}}
     </div>
   {{/in-element}}
 {{/if}}

--- a/stories/4-components/Content/AuModal.stories.js
+++ b/stories/4-components/Content/AuModal.stories.js
@@ -31,17 +31,16 @@ const Template = (args) => ({
     <AuModal
       @modalOpen={{this.modalOpen}}
       @closeModal={{this.closeModal}}
-      @title={{this.title}}
       @size={{this.size}}
       @padding={{this.padding}}
-      as |Modal|
     >
-      <Modal.Body>
+      <:title>{{this.title}}</:title>
+      <:body>
         <p>Modal content</p>
-      </Modal.Body>
-      <Modal.Footer>
+      </:body>
+      <:footer>
         <AuButton>Action</AuButton>
-      </Modal.Footer>
+      </:footer>
     </AuModal>`,
   context: args,
 });

--- a/tests/integration/components/au-modal-test.js
+++ b/tests/integration/components/au-modal-test.js
@@ -3,31 +3,110 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, render, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
+const MODAL = {
+  ELEMENT: '[data-test-modal]',
+  HEADER: '[data-test-modal-header]',
+  CLOSE: '[data-test-modal-close]',
+  TITLE: '[data-test-modal-title]',
+  BODY: '[data-test-modal-body]',
+  FOOTER: '[data-test-modal-footer]',
+};
+
+function getWormholeElement() {
+  return document.querySelector('#ember-appuniversum-wormhole');
+}
+
 module('Integration | Component | au-modal', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
+  test('it renders when @modalOpen is set to `true`', async function (assert) {
     await render(hbs`<AuModal />`);
+    assert.dom(MODAL.ELEMENT, getWormholeElement()).doesNotExist();
 
-    assert.dom(this.element).hasText('');
+    await render(hbs`<AuModal @modalOpen={{true}} />`);
+    assert.dom(MODAL.ELEMENT, getWormholeElement()).exists();
+  });
 
-    // Template block usage:
+  test('it yields body and footer components', async function (assert) {
     await render(hbs`
       <AuModal @modalOpen={{true}} as |Modal|>
         <Modal.Body>
-          template block text
+          Body
         </Modal.Body>
+        <Modal.Footer>
+          Footer
+        </Modal.Footer>
       </AuModal>
     `);
 
-    // the wormhole exists outside of the test dom,
-    // so we explicitly pass in the document as rootelement here
+    assert.dom(MODAL.BODY, getWormholeElement()).containsText('Body');
+    assert.dom(MODAL.FOOTER, getWormholeElement()).containsText('Footer');
+  });
+
+  test('it has named blocks for the body and footer', async function (assert) {
+    await render(hbs`
+      <AuModal @modalOpen={{true}}>
+        <:body>Body</:body>
+        <:footer>Footer</:footer>
+      </AuModal>
+    `);
+
+    assert.dom(MODAL.BODY, getWormholeElement()).hasText('Body');
+    assert.dom(MODAL.FOOTER, getWormholeElement()).hasText('Footer');
+  });
+
+  test('it stops yielding the contextual components once a named block is used', async function (assert) {
+    await render(hbs`
+      <AuModal @modalOpen={{true}}>
+        <:default as |Modal|>
+          <Modal.Body>Not rendered</Modal.Body>
+          <Modal.Footer>Not rendered</Modal.Footer>
+        </:default>
+        <:body>Body</:body>
+        <:footer>Footer</:footer>
+      </AuModal>
+    `);
+
     assert
-      .dom('#ember-appuniversum-wormhole', document)
-      .containsText('template block text');
+      .dom(MODAL.BODY, getWormholeElement())
+      .exists({ count: 1 })
+      .hasText('Body');
+
+    assert
+      .dom(MODAL.FOOTER, getWormholeElement())
+      .exists({ count: 1 })
+      .hasText('Footer');
+  });
+
+  test("it's title can be set through an argument or a named block", async function (assert) {
+    await render(hbs`
+      <AuModal @title="Title set through @title" @modalOpen={{true}}/>
+    `);
+
+    assert
+      .dom(MODAL.TITLE, getWormholeElement())
+      .hasText('Title set through @title');
+
+    await render(hbs`
+      <AuModal @modalOpen={{true}}>
+        <:title>Title set through block</:title>
+      </AuModal>
+    `);
+
+    assert
+      .dom(MODAL.TITLE, getWormholeElement())
+      .hasText('Title set through block');
+
+    // the block version is prioritized
+    await render(hbs`
+      <AuModal @title="Title set through @title" @modalOpen={{true}}>
+        <:title>Title set through block</:title>
+      </AuModal>
+    `);
+
+    assert
+      .dom(MODAL.TITLE, getWormholeElement())
+      .hasText('Title set through block');
   });
 
   test('it calls `@closeModal` when the modal should be closed', async function (assert) {
@@ -43,7 +122,7 @@ module('Integration | Component | au-modal', function (hooks) {
       <AuModal @modalOpen={{this.isOpen}} @closeModal={{this.handleClose}}></AuModal>
     `);
 
-    let closeButton = document.querySelector('[data-test-au-modal-close]');
+    let closeButton = document.querySelector(MODAL.CLOSE);
     await click(closeButton);
     assert.equal(timesCalled, 1);
 
@@ -72,7 +151,7 @@ module('Integration | Component | au-modal', function (hooks) {
       {{/if}}
     `);
 
-    let closeButton = document.querySelector('[data-test-close-button]');
+    let closeButton = document.querySelector(MODAL.CLOSE);
     await click(closeButton);
     assert.equal(timesCalled, 1);
   });


### PR DESCRIPTION
This modernizes the component by adding `title`, `body` and `footer` named blocks. The non-block version is still fully supported to keep the change backwards compatible.

New usage:
```hbs
      <AuModal @modalOpen={{true}}>
        <:title>Some title</:title>
        <:body>Body</:body>
        <:footer>Footer</:footer>
      </AuModal>
```
We could also add deprecations to guide users to the newer version?