### PR TITLE
Add a `@type` argument to the AuInput component

### DIFF
--- a/addon/components/au-input.hbs
+++ b/addon/components/au-input.hbs
@@ -1,20 +1,66 @@
 {{#if @icon}}
   <span class="au-c-input-wrapper {{this.iconAlignment}} {{this.width}}">
     {{#if @mask}}
-    <Inputmask class="au-c-input au-c-input--mask {{this.error}} {{this.warning}} {{this.width}} {{this.disabled}}" @value={{@value}} @mask={{@mask}} @placeholder={{@maskPlaceholder}} @update={{this.handleChange}} disabled={{@disabled}} ...attributes/>
+      <Inputmask
+        @value={{@value}}
+        @mask={{@mask}}
+        @placeholder={{@maskPlaceholder}}
+        @update={{this.handleChange}}
+        class="au-c-input au-c-input--mask
+          {{this.error}}
+          {{this.warning}}
+          {{this.width}}
+          {{this.disabled}}"
+        disabled={{@disabled}}
+        type={{this.type}}
+        ...attributes
+      />
     {{else}}
-    <Input class="au-c-input {{this.error}} {{this.warning}} {{this.width}} {{this.disabled}}" @value={{@value}} disabled={{@disabled}} ...attributes/>
+      <Input
+        @value={{@value}}
+        @type={{this.type}}
+        class="au-c-input
+          {{this.error}}
+          {{this.warning}}
+          {{this.width}}
+          {{this.disabled}}"
+        disabled={{@disabled}}
+        ...attributes
+      />
     {{/if}}
     {{#if (eq @iconAlignment "right")}}
-    <AuIcon @icon="{{@icon}}" @alignment="right" />
+      <AuIcon @icon={{@icon}} @alignment="right" />
     {{else}}
-    <AuIcon @icon="{{@icon}}" @alignment="left" />
+      <AuIcon @icon={{@icon}} @alignment="left" />
     {{/if}}
   </span>
 {{else}}
-{{#if @mask}}
-<Inputmask class="au-c-input au-c-input--mask {{this.error}} {{this.warning}} {{this.width}} {{this.disabled}}" @value={{@value}} @mask={{@mask}} @placeholder={{@maskPlaceholder}} @update={{this.handleChange}} disabled={{@disabled}} ...attributes/>
-{{else}}
-<Input class="au-c-input {{this.error}} {{this.warning}} {{this.width}} {{this.disabled}}" @value={{@value}} disabled={{@disabled}} ...attributes/>
-{{/if}}
+  {{#if @mask}}
+    <Inputmask
+      @value={{@value}}
+      @mask={{@mask}}
+      @placeholder={{@maskPlaceholder}}
+      @update={{this.handleChange}}
+      class="au-c-input au-c-input--mask
+        {{this.error}}
+        {{this.warning}}
+        {{this.width}}
+        {{this.disabled}}"
+      disabled={{@disabled}}
+      type={{this.type}}
+      ...attributes
+    />
+  {{else}}
+    <Input
+      @value={{@value}}
+      @type={{this.type}}
+      class="au-c-input
+        {{this.error}}
+        {{this.warning}}
+        {{this.width}}
+        {{this.disabled}}"
+      disabled={{@disabled}}
+      ...attributes
+    />
+  {{/if}}
 {{/if}}

--- a/addon/components/au-input.js
+++ b/addon/components/au-input.js
@@ -39,6 +39,10 @@ export default class AuInput extends Component {
     else return '';
   }
 
+  get type() {
+    return this.args.type || 'text';
+  }
+
   @action
   handleChange(value) {
     this.args.onChange?.(value);

--- a/stories/4-components/Forms/AuInput.stories.js
+++ b/stories/4-components/Forms/AuInput.stories.js
@@ -41,6 +41,10 @@ export default {
       description:
         'This action will be called when the value changes and will be passed to the unmasked value and the masked value.',
     },
+    type: {
+      control: 'select',
+      options: ['text', 'number'],
+    },
   },
   parameters: {
     layout: 'padded',
@@ -60,6 +64,7 @@ const Template = (args) => ({
       @mask={{this.mask}}
       @maskPlaceholder={{this.maskPlaceholder}}
       @handleChange={{this.handleChange}}
+      @type={{this.type}}
     />`,
   context: args,
 });

--- a/tests/integration/components/au-input-test.js
+++ b/tests/integration/components/au-input-test.js
@@ -6,12 +6,13 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | au-input', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  test("it's possible to set the type", async function (assert) {
+    await render(hbs`<AuInput @type={{this.type}} />`);
+    assert
+      .dom('input')
+      .hasAttribute('type', 'text', 'it defaults to type="text"');
 
-    await render(hbs`<AuInput />`);
-
-    assert.dom(this.element).hasText('');
+    this.set('type', 'number');
+    assert.dom('input').hasAttribute('type', 'number');
   });
 });


### PR DESCRIPTION
Ember's Input component requires that the type is passed as an argument instead of an attribute. [This has always been documented like this](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Input#input-html-attributes-to-avoid) but somewhere between 3.24 and 3.28 it stopped supporting the attribute version.

Closes #217 