### PR TITLE
Use a native input element in the `AuControlCheckbox` component

### DIFF
--- a/addon/components/au-control-checkbox.hbs
+++ b/addon/components/au-control-checkbox.hbs
@@ -1,5 +1,17 @@
-<label for="{{@identifier}}" class="au-c-control au-c-control--checkbox {{this.disabled}}">
-  <Input class="au-c-control__input" id="{{@identifier}}" name="{{@name}}" disabled={{@disabled}} @type="checkbox" @checked={{@checked}} {{on "change" this.onChange}} ...attributes />
+<label
+  for={{@identifier}}
+  class="au-c-control au-c-control--checkbox {{this.disabled}}"
+>
+  <input
+    class="au-c-control__input"
+    id={{@identifier}}
+    name={{@name}}
+    disabled={{@disabled}}
+    type="checkbox"
+    checked={{@checked}}
+    {{on "change" this.onChange}}
+    ...attributes
+  />
   <span class="au-c-control__indicator"></span>
   {{@label}}
 </label>


### PR DESCRIPTION
The `Input` component provides no benefits since we already required the `onChange` argument. The 2-way-binding isn't needed here.