### PR TITLE
`on-click-inside` modifier improvements

### DIFF
--- a/addon/modifiers/on-click-inside.js
+++ b/addon/modifiers/on-click-inside.js
@@ -1,15 +1,18 @@
 import { modifier } from 'ember-modifier';
 
-export default modifier(function onClickInside(element, [callback]) {
-  function handleClick(event) {
-    if (element.contains(event.target)) {
-      callback();
+export default modifier(
+  function onClickInside(element, [callback]) {
+    function handleClick(event) {
+      if (element.contains(event.target)) {
+        callback();
+      }
     }
-  }
 
-  document.addEventListener('click', handleClick);
+    document.addEventListener('click', handleClick);
 
-  return () => {
-    document.removeEventListener('click', handleClick);
-  };
-});
+    return () => {
+      document.removeEventListener('click', handleClick);
+    };
+  },
+  { eager: false }
+);

--- a/addon/modifiers/on-click-inside.js
+++ b/addon/modifiers/on-click-inside.js
@@ -2,16 +2,14 @@ import { modifier } from 'ember-modifier';
 
 export default modifier(
   function onClickInside(element, [callback]) {
-    function handleClick(event) {
-      if (element.contains(event.target)) {
-        callback();
-      }
+    function handleClick() {
+      callback();
     }
 
-    document.addEventListener('click', handleClick);
+    element.addEventListener('click', handleClick);
 
     return () => {
-      document.removeEventListener('click', handleClick);
+      element.removeEventListener('click', handleClick);
     };
   },
   { eager: false }

--- a/tests/integration/modifiers/on-click-inside-test.js
+++ b/tests/integration/modifiers/on-click-inside-test.js
@@ -1,15 +1,39 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Modifier | on-click-inside', function (hooks) {
   setupRenderingTest(hooks);
 
-  // Replace this with your real tests.
-  test('it renders', async function (assert) {
-    await render(hbs`<div {{on-click-inside}}></div>`);
+  test('it calls the provided function when clicking the element or one of its children', async function (assert) {
+    this.handleClick = () => {
+      assert.step('clicked');
+    };
 
-    assert.ok(true);
+    await render(hbs`
+      <div {{on-click-inside this.handleClick}}>
+        <button type="button" data-test-inside-button>Inside</button>
+      </div>
+      <button type="button" data-test-outside-button>Outside</button>
+    `);
+
+    await click('[data-test-inside-button]');
+    assert.verifySteps(
+      ['clicked'],
+      'clicking a child element triggers the callback'
+    );
+
+    await click('[data-test-outside-button]');
+    assert.verifySteps(
+      [],
+      "clicking an outside element doesn't trigger the callback"
+    );
+
+    await click('div');
+    assert.verifySteps(
+      ['clicked'],
+      'clicking the element itself also calls the callback'
+    );
   });
 });


### PR DESCRIPTION
- add some tests
- resolve the ember-modifier v3.2 deprecation warning (#223)
- simplify the implementation