### PR TITLE
Deprecate the `alert` prefixed argument names of the `AuAlert` component

### DIFF
--- a/addon/components/au-alert.hbs
+++ b/addon/components/au-alert.hbs
@@ -1,21 +1,35 @@
-{{#if this.alertVisible}}
-<div class="au-c-alert {{this.alertSkin}} {{this.alertSize}}" role="alert" ...attributes>
-  {{#if @alertIcon}}
-  <div class="au-c-alert__icon" aria-hidden="{{if @iconVisible "false" "true"}}">
-    <AuIcon @icon="{{@alertIcon}}" />
-  </div>
-  {{/if}}
-  <div class="au-c-alert__content">
-    {{#if @alertTitle}}
-    <p class="au-c-alert__title">{{@alertTitle}}</p>
+{{#if this.isVisible}}
+  <div
+    class="au-c-alert {{this.skin}} {{this.size}}"
+    role="alert"
+    data-test-alert
+    ...attributes
+  >
+    {{#if this.icon}}
+      <div
+        class="au-c-alert__icon"
+        aria-hidden={{if @iconVisible "false" "true"}}
+        data-test-alert-icon
+      >
+        <AuIcon @icon={{this.icon}} />
+      </div>
     {{/if}}
-    <div class="au-c-alert__message">{{yield}}</div>
+    <div class="au-c-alert__content">
+      {{#if this.title}}
+        <p class="au-c-alert__title" data-test-alert-title>{{this.title}}</p>
+      {{/if}}
+      <div class="au-c-alert__message" data-test-alert-message>{{yield}}</div>
+    </div>
+    {{#if @closable}}
+      <button
+        class="au-c-alert__close"
+        type="button"
+        data-test-alert-close
+        {{on "click" this.closeAlert}}
+      >
+        <AuIcon @icon="cross" @size="large" />
+        <span class="au-u-hidden-visually">Sluit alert</span>
+      </button>
+    {{/if}}
   </div>
-  {{#if @closable}}
-  <button type="button" {{on "click" this.closeAlert}} class="au-c-alert__close">
-    <AuIcon @icon="cross" @size="large" />
-    <span class="au-u-hidden-visually">Sluit alert</span>
-  </button>
-  {{/if}}
-</div>
 {{/if}}

--- a/addon/components/au-alert.js
+++ b/addon/components/au-alert.js
@@ -1,29 +1,90 @@
 import Component from '@glimmer/component';
+import { deprecate } from '@ember/debug';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class AuAlertComponent extends Component {
-  get alertSkin() {
-    if (this.args.alertSkin == 'info') return 'au-c-alert--info';
-    if (this.args.alertSkin == 'success') return 'au-c-alert--success';
-    if (this.args.alertSkin == 'warning') return 'au-c-alert--warning';
-    if (this.args.alertSkin == 'error') return 'au-c-alert--error';
+  @tracked isVisible = true;
+
+  get skin() {
+    deprecate(
+      '@alertSkin is deprecated, use @skin instead',
+      !this.args.alertSkin,
+      {
+        id: '@appuniversum/ember-appuniversum.au-alert.alertSkin-argument',
+        until: '2.0.0',
+        for: '@appuniversum/ember-appuniversum',
+        since: {
+          enabled: '1.1.0',
+        },
+      }
+    );
+
+    let skin = this.args.alertSkin || this.args.skin;
+
+    if (skin === 'info') return 'au-c-alert--info';
+    if (skin === 'success') return 'au-c-alert--success';
+    if (skin == 'warning') return 'au-c-alert--warning';
+    if (skin == 'error') return 'au-c-alert--error';
     return '';
   }
 
-  get alertSize() {
-    if (this.args.alertSize == 'tiny') return 'au-c-alert--tiny';
-    if (this.args.alertSize == 'small') return 'au-c-alert--small';
+  get size() {
+    deprecate(
+      '@alertSize is deprecated, use @size instead',
+      !this.args.alertSize,
+      {
+        id: '@appuniversum/ember-appuniversum.au-alert.alertSize-argument',
+        until: '2.0.0',
+        for: '@appuniversum/ember-appuniversum',
+        since: {
+          enabled: '1.1.0',
+        },
+      }
+    );
+
+    let size = this.args.alertSize || this.args.size;
+    if (size === 'tiny') return 'au-c-alert--tiny';
+    if (size === 'small') return 'au-c-alert--small';
     return '';
+  }
+
+  get icon() {
+    deprecate(
+      '@alertIcon is deprecated, use @icon instead',
+      !this.args.alertIcon,
+      {
+        id: '@appuniversum/ember-appuniversum.au-alert.alertIcon-argument',
+        until: '2.0.0',
+        for: '@appuniversum/ember-appuniversum',
+        since: {
+          enabled: '1.1.0',
+        },
+      }
+    );
+    return this.args.alertIcon || this.args.icon;
+  }
+
+  get title() {
+    deprecate(
+      '@alertTitle is deprecated, use @title instead',
+      !this.args.alertTitle,
+      {
+        id: '@appuniversum/ember-appuniversum.au-alert.alertTitle-argument',
+        until: '2.0.0',
+        for: '@appuniversum/ember-appuniversum',
+        since: {
+          enabled: '1.1.0',
+        },
+      }
+    );
+    return this.args.alertTitle || this.args.title;
   }
 
   // @TODO: add icon switching functionality
 
-  // Close alert
-  @tracked alertVisible = true;
-
   @action
   closeAlert() {
-    this.alertVisible = !this.alertVisible;
+    this.isVisible = !this.isVisible;
   }
 }

--- a/stories/4-components/Notifications/AuAlert.stories.js
+++ b/stories/4-components/Notifications/AuAlert.stories.js
@@ -17,7 +17,7 @@ export default {
     },
     size: {
       control: 'select',
-      options: ['default', 'small'],
+      options: ['default', 'small', 'tiny'],
       description: 'Set the size of the alert',
     },
     closable: { control: 'boolean', description: 'Makes the alert closable' },
@@ -30,10 +30,10 @@ export default {
 const Template = (args) => ({
   template: hbs`
     <AuAlert
-      @alertTitle={{this.title}}
-      @alertSkin={{this.skin}}
-      @alertIcon={{this.icon}}
-      @alertSize={{this.size}}
+      @title={{this.title}}
+      @skin={{this.skin}}
+      @icon={{this.icon}}
+      @size={{this.size}}
       @closable={{this.closable}}
     >
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>

--- a/tests/integration/components/au-alert-test.js
+++ b/tests/integration/components/au-alert-test.js
@@ -1,26 +1,168 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, getDeprecations, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+
+const ALERT = {
+  CONTAINER: '[data-test-alert]',
+  MESSAGE: '[data-test-alert-message]',
+  ICON: '[data-test-alert-icon]',
+  TITLE: '[data-test-alert-title]',
+  CLOSE: '[data-test-alert-close]',
+};
 
 module('Integration | Component | au-alert', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
-    await render(hbs`<AuAlert />`);
-
-    assert.dom(this.element).hasText('');
-
-    // Template block usage:
+  test('it uses the block content as the alert message', async function (assert) {
     await render(hbs`
       <AuAlert>
-        template block text
+        message
       </AuAlert>
     `);
 
-    assert.dom(this.element).hasText('template block text');
+    assert.dom(ALERT.MESSAGE).hasText('message');
+  });
+
+  test('it can render an icon', async function (assert) {
+    await render(hbs`
+      <AuAlert @icon={{this.icon}}>
+        message
+      </AuAlert>
+    `);
+
+    assert.dom(ALERT.ICON).doesNotExist();
+
+    this.set('icon', 'circle-info');
+    assert.dom(ALERT.ICON).exists();
+  });
+
+  test('it can render an icon with the deprecated argument name', async function (assert) {
+    await render(hbs`
+      <AuAlert @alertIcon={{this.icon}}>
+        message
+      </AuAlert>
+    `);
+
+    assert.dom(ALERT.ICON).doesNotExist();
+
+    this.set('icon', 'circle-info');
+    assert.dom(ALERT.ICON).exists();
+  });
+
+  test('it can render a title', async function (assert) {
+    await render(hbs`
+      <AuAlert @title={{this.title}}>
+        message
+      </AuAlert>
+    `);
+
+    assert.dom(ALERT.TITLE).doesNotExist();
+
+    this.set('title', 'some title');
+    assert.dom(ALERT.TITLE).hasText('some title');
+  });
+
+  test('it can render a title with the deprecated argument name', async function (assert) {
+    await render(hbs`
+      <AuAlert @alertTitle={{this.title}}>
+        message
+      </AuAlert>
+    `);
+
+    assert.dom(ALERT.TITLE).doesNotExist();
+
+    this.set('title', 'some title');
+    assert.dom(ALERT.TITLE).hasText('some title');
+  });
+
+  test('it can be closed', async function (assert) {
+    await render(hbs`
+      <AuAlert @closable={{this.closable}}>
+        message
+      </AuAlert>
+    `);
+
+    assert.dom(ALERT.CLOSE).doesNotExist();
+
+    this.set('closable', true);
+    assert.dom(ALERT.CLOSE).exists();
+
+    assert
+      .dom(ALERT.CONTAINER)
+      .isVisible('the alert is visible before clicking the close button');
+
+    await click(ALERT.CLOSE);
+    assert
+      .dom(ALERT.CONTAINER)
+      .isNotVisible('it hides the alert after clicking the close button');
+  });
+
+  test('it throws a deprecation warning when `@alertSkin` is used', async function (assert) {
+    await render(hbs`<AuAlert
+      @skin="info"
+    >bar</AuAlert>`);
+
+    assert.true(hasNoDeprecations());
+
+    await render(hbs`<AuAlert
+      @alertSkin="info"
+    >bar</AuAlert>`);
+
+    assert.true(hasDeprecation('@alertSkin is deprecated, use @skin instead'));
+  });
+
+  test('it throws a deprecation warning when `@alertSize` is used', async function (assert) {
+    await render(hbs`<AuAlert
+      @size="tiny"
+    >bar</AuAlert>`);
+
+    assert.true(hasNoDeprecations());
+
+    await render(hbs`<AuAlert
+      @alertSize="tiny"
+    >bar</AuAlert>`);
+
+    assert.true(hasDeprecation('@alertSize is deprecated, use @size instead'));
+  });
+
+  test('it throws a deprecation warning when `@alertIcon` is used', async function (assert) {
+    await render(hbs`<AuAlert
+      @icon="tiny"
+    >bar</AuAlert>`);
+
+    assert.true(hasNoDeprecations());
+
+    await render(hbs`<AuAlert
+      @alertIcon="info"
+    >bar</AuAlert>`);
+
+    assert.true(hasDeprecation('@alertIcon is deprecated, use @icon instead'));
+  });
+
+  test('it throws a deprecation warning when `@alertTitle` is used', async function (assert) {
+    await render(hbs`<AuAlert
+      @title="foo"
+    >bar</AuAlert>`);
+
+    assert.true(hasNoDeprecations());
+
+    await render(hbs`<AuAlert
+      @alertTitle="foo"
+    >bar</AuAlert>`);
+
+    assert.true(
+      hasDeprecation('@alertTitle is deprecated, use @title instead')
+    );
   });
 });
+
+function hasNoDeprecations() {
+  return getDeprecations().length === 0;
+}
+
+function hasDeprecation(deprecationMessage) {
+  return getDeprecations().some(
+    (deprecation) => deprecation.message === deprecationMessage
+  );
+}


### PR DESCRIPTION
This deprecates the `alert` prefixed argument names for the `AuAlert` component.

I also added some tests since it didn't have any yet.

Closes #236 