### PR TITLE
`AuTimepicker` fixes

### DIFF
--- a/addon/components/au-time-picker.hbs
+++ b/addon/components/au-time-picker.hbs
@@ -2,7 +2,7 @@
   <div class="au-time-picker__box">
     <AuLabel for="input-hour">{{@hoursLabel}}</AuLabel>
     <div class="au-time-picker__input-wrapper">
-      <AuInput class="au-time-picker__input" value={{format-time-digit this.hourValue}} name="input-hour" id="input-hour"
+      <AuInput class="au-time-picker__input" @value={{format-time-digit this.hourValue}} name="input-hour" id="input-hour"
         {{on 'keyup' (fn this.setTimeValue "hourValue")}}
         {{on 'focusout' (fn this.updateTime "hourValue")}}
       />
@@ -18,7 +18,7 @@
   <div class="au-time-picker__box">
     <AuLabel for="input-minute">{{@minutesLabel}}</AuLabel>
     <div class="au-time-picker__input-wrapper">
-      <AuInput class="au-time-picker__input" value={{format-time-digit this.minuteValue}} name="input-minute" id="input-minute"
+      <AuInput class="au-time-picker__input" @value={{format-time-digit this.minuteValue}} name="input-minute" id="input-minute"
         {{on 'keyup' (fn this.setTimeValue "minuteValue")}}
         {{on 'focusout' (fn this.updateTime "minuteValue")}}
       />
@@ -35,7 +35,7 @@
     <div class="au-time-picker__box">
       <AuLabel for="input-second">{{@secondsLabel}}</AuLabel>
       <div class="au-time-picker__input-wrapper">
-        <AuInput class="au-time-picker__input" value={{format-time-digit this.secondValue}} name="input-second" id="input-second"
+        <AuInput class="au-time-picker__input" @value={{format-time-digit this.secondValue}} name="input-second" id="input-second"
           {{on 'keyup' (fn this.setTimeValue "secondValue")}}
           {{on 'focusout' (fn this.updateTime "secondValue")}}
         />

--- a/addon/components/au-time-picker.js
+++ b/addon/components/au-time-picker.js
@@ -14,9 +14,9 @@ export default class AuTimePickerComponent extends Component {
 
   get getTimeObject() {
     return {
-      hours: this.hourValue,
-      minutes: this.minuteValue,
-      seconds: this.secondValue,
+      hours: parseInt(this.hourValue),
+      minutes: parseInt(this.minuteValue),
+      seconds: parseInt(this.secondValue),
     };
   }
 

--- a/addon/components/au-time-picker.js
+++ b/addon/components/au-time-picker.js
@@ -128,7 +128,7 @@ export default class AuTimePickerComponent extends Component {
 
   @action
   callBackParent(value) {
-    if (this.args.onChange != undefined) {
+    if (typeof this.args.onChange === 'function') {
       this.args.onChange(value);
     }
   }


### PR DESCRIPTION
- make sure the values are shown in Ember 3.27+
- only call `@onChange` if it's a function (this was throwing errors in Storybook)
- ensure integer values are returned instead of strings

This fixes the [Storybook example](https://appuniversum.github.io/ember-appuniversum/?path=/story/components-forms-autimepicker--component) and was causing issues in one of the LBLOD projects. 