### PR TITLE
yield the `AuToolbarGroup` component from the `AuToolbar` component

### DIFF
--- a/addon/components/au-accordion.hbs
+++ b/addon/components/au-accordion.hbs
@@ -4,8 +4,9 @@
     @reverse={{@reverse}}
     {{on 'click' this.openAccordion}}
     data-test-accordion-toggle
+    as |Group|
   >
-    <AuToolbarGroup>
+    <Group>
       <div>
         <AuButton
           @skin='tertiary'
@@ -20,8 +21,8 @@
           {{this.subtitle}}
         </p>
       </div>
-    </AuToolbarGroup>
-    <AuToolbarGroup>
+    </Group>
+    <Group>
       {{#if this.accordionOpen}}
         <AuIcon
           @icon={{this.iconOpen}}
@@ -45,7 +46,7 @@
           Sluit accordion
         </span>
       {{/if}}
-    </AuToolbarGroup>
+    </Group>
   </AuToolbar>
   {{#if this.accordionOpen}}
     <AuContent {{auto-focus}} tabindex='0' data-test-accordion-content>

--- a/addon/components/au-toolbar-group.js
+++ b/addon/components/au-toolbar-group.js
@@ -1,0 +1,22 @@
+import Component from '@glimmer/component';
+import { deprecate } from '@ember/debug';
+
+// TODO Cleanup v2: Remove this file and move the template to the components/au-toolbar/group.hbs
+export default class AuToolbarGroupComponent extends Component {
+  constructor() {
+    super(...arguments);
+
+    deprecate(
+      'Invoking `AuToolbarGroup` directly is deprecated. You should use the component that is yielded from the `AuToolbar` component instead.',
+      this.args.wasYielded,
+      {
+        id: '@appuniversum/ember-appuniversum.au-toolbar-group.direct-invocation',
+        until: '2.0.0',
+        for: '@appuniversum/ember-appuniversum',
+        since: {
+          enabled: '1.1.0',
+        },
+      }
+    );
+  }
+}

--- a/addon/components/au-toolbar.hbs
+++ b/addon/components/au-toolbar.hbs
@@ -1,3 +1,3 @@
 <div class="au-c-toolbar {{this.reverse}} {{this.border}} {{this.skin}} {{this.size}} {{this.nowrap}}" ...attributes>
-  {{yield (component "au-toolbar-group")}}
+  {{yield (component "au-toolbar-group" wasYielded=true)}}
 </div>

--- a/addon/components/au-toolbar.hbs
+++ b/addon/components/au-toolbar.hbs
@@ -1,3 +1,3 @@
 <div class="au-c-toolbar {{this.reverse}} {{this.border}} {{this.skin}} {{this.size}} {{this.nowrap}}" ...attributes>
-  {{yield}}
+  {{yield (component "au-toolbar-group")}}
 </div>

--- a/stories/4-components/Content/AuCard.stories.js
+++ b/stories/4-components/Content/AuCard.stories.js
@@ -130,15 +130,15 @@ const ExpandableTemplate = (args) => ({
 
 const EditableTemplate = (args) => ({
   template: hbs`
-    <AuToolbar class="au-u-margin-bottom-small">
-      <AuToolbarGroup>
+    <AuToolbar class="au-u-margin-bottom-small" as |Group|>
+      <Group>
         <AuHeading @level="4" @skin="5">Card – editable</AuHeading>
-      </AuToolbarGroup>
-      <AuToolbarGroup>
+      </Group>
+      <Group>
         <AuButton @skin="tertiary" @icon="pencil" @iconAlignment="right">
           Bewerk
         </AuButton>
-      </AuToolbarGroup>
+      </Group>
     </AuToolbar>
     <AuCard
       @flex={{this.flex}}
@@ -181,15 +181,15 @@ const EditableTemplate = (args) => ({
 
 const EditingTemplate = (args) => ({
   template: hbs`
-    <AuToolbar class="au-u-margin-bottom-small">
-      <AuToolbarGroup>
+    <AuToolbar class="au-u-margin-bottom-small" as |Group|>
+      <Group>
         <AuHeading @level="4" @skin="5">Card – editing</AuHeading>
-      </AuToolbarGroup>
-      <AuToolbarGroup>
+      </Group>
+      <Group>
         <AuButton @icon="check" @iconAlignment="right">
           Bewaar
         </AuButton>
-      </AuToolbarGroup>
+      </Group>
     </AuToolbar>
     <AuCard
       @flex={{this.flex}}

--- a/stories/4-components/Layout/AuToolbar.stories.js
+++ b/stories/4-components/Layout/AuToolbar.stories.js
@@ -41,8 +41,9 @@ const Template = (args) => ({
       @skin={{this.skin}}
       @size={{this.size}}
       @nowrap={{this.nowrap}}
+      as |Group|
     >
-      <AuToolbarGroup>
+      <Group>
         <AuButtonGroup>
           <AuButton>
             Primary button
@@ -51,12 +52,12 @@ const Template = (args) => ({
             Secondary button
           </AuButton>
         </AuButtonGroup>
-      </AuToolbarGroup>
-      <AuToolbarGroup>
+      </Group>
+      <Group>
         <AuLink @skin="secondary">
           Secondary link
         </AuLink>
-      </AuToolbarGroup>
+      </Group>
     </AuToolbar>`,
   context: args,
 });

--- a/stories/4-components/Tables/AuDataTable.stories.js
+++ b/stories/4-components/Tables/AuDataTable.stories.js
@@ -19,18 +19,18 @@ const Template = (args) => ({
     >
       <t.menu as |menu|>
         <menu.general>
-          <AuToolbar class="au-o-box">
-            <AuToolbarGroup>
+          <AuToolbar class="au-o-box" as |Group|>
+            <Group>
               <AuHeading @skin="2">
                 Notulen zitting
               </AuHeading>
-            </AuToolbarGroup>
-            <AuToolbarGroup class="au-c-toolbar__group--center">
+            </Group>
+            <Group class="au-c-toolbar__group--center">
               <AuDataTableTextSearch @filter={{this.title}} @placeholder="Zoek titel notulen" />
               <AuButton>
                 Nieuwe zitting
               </AuButton>
-            </AuToolbarGroup>
+            </Group>
           </AuToolbar>
         </menu.general>
       </t.menu>

--- a/stories/6-templates/AppBreadcrumbs.stories.js
+++ b/stories/6-templates/AppBreadcrumbs.stories.js
@@ -17,8 +17,8 @@ const Template = (args) => ({
           </AuButton>
         </AuDropdown>
       </AuMainHeader>
-      <AuToolbar @size="medium" @skin="tint" @border="bottom">
-        <AuToolbarGroup>
+      <AuToolbar @size="medium" @skin="tint" @border="bottom" as |Group|>
+        <Group>
           <ul class="au-c-list-horizontal au-c-list-horizontal--small">
             <li class="au-c-list-horizontal__item">
               <AuLink @linkRoute="index">
@@ -30,7 +30,7 @@ const Template = (args) => ({
               Test
             </li>
           </ul>
-        </AuToolbarGroup>
+        </Group>
       </AuToolbar>
       <AuMainContainer as |m|>
         <m.content @scroll={{true}}>

--- a/stories/6-templates/AppEditor.stories.js
+++ b/stories/6-templates/AppEditor.stories.js
@@ -12,15 +12,15 @@ const Template = (args) => ({
     <AuApp>
       <nav>
         <div class="au-c-app-chrome">
-          <AuToolbar @size="small" class="au-u-padding-bottom-none">
-            <AuToolbarGroup>
+          <AuToolbar @size="small" class="au-u-padding-bottom-none" as |Group|>
+            <Group>
               <AuLink @route="docs.templates.app-editor" @skin="secondary">
                 <AuIcon @icon="arrow-left" @alignment="left" />
                 Terug naar overzicht agendapunten
               </AuLink>
               <span class="au-c-app-chrome__entity">Title</span>
-            </AuToolbarGroup>
-            <AuToolbarGroup>
+            </Group>
+            <Group>
               <ul class="au-c-list-horizontal au-u-padding-right-tiny">
                 <li class="au-c-list-horizontal__item">
                   <span class="au-c-app-chrome__status">
@@ -28,10 +28,10 @@ const Template = (args) => ({
                   </span>
                 </li>
               </ul>
-            </AuToolbarGroup>
+            </Group>
           </AuToolbar>
-          <AuToolbar @size="small" class="au-u-padding-top-none">
-            <AuToolbarGroup>
+          <AuToolbar @size="small" class="au-u-padding-top-none" as |Group|>
+            <Group>
               <div>
                 <AuPill @skin="warning">
                   <AuIcon @icon="alert-triangle" @alignment="left" />
@@ -41,8 +41,8 @@ const Template = (args) => ({
               <h1 class="au-c-app-chrome__title">
                 Title
               </h1>
-            </AuToolbarGroup>
-            <AuToolbarGroup class="au-c-toolbar__group--actions">
+            </Group>
+            <Group class="au-c-toolbar__group--actions">
               <AuDropdown @title="Bestand acties" @buttonLabel="Bestand opties" @alignment="right">
                 <AuButton @skin="tertiary" role="menuitem">
                   <AuIcon @icon="copy" @alignment="left" />
@@ -58,7 +58,7 @@ const Template = (args) => ({
                 </AuButton>
               </AuDropdown>
               <AuButton>Bewaar</AuButton>
-            </AuToolbarGroup>
+            </Group>
           </AuToolbar>
         </div>
       </nav>

--- a/tests/helpers/deprecations.js
+++ b/tests/helpers/deprecations.js
@@ -1,0 +1,11 @@
+import { getDeprecations } from '@ember/test-helpers';
+
+export function hasNoDeprecations() {
+  return getDeprecations().length === 0;
+}
+
+export function hasDeprecation(deprecationMessage) {
+  return getDeprecations().some(
+    (deprecation) => deprecation.message === deprecationMessage
+  );
+}

--- a/tests/integration/components/au-alert-test.js
+++ b/tests/integration/components/au-alert-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, getDeprecations, render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { hasDeprecation, hasNoDeprecations } from '../../helpers/deprecations';
 
 const ALERT = {
   CONTAINER: '[data-test-alert]',
@@ -156,13 +157,3 @@ module('Integration | Component | au-alert', function (hooks) {
     );
   });
 });
-
-function hasNoDeprecations() {
-  return getDeprecations().length === 0;
-}
-
-function hasDeprecation(deprecationMessage) {
-  return getDeprecations().some(
-    (deprecation) => deprecation.message === deprecationMessage
-  );
-}

--- a/tests/integration/components/au-toolbar-group-test.js
+++ b/tests/integration/components/au-toolbar-group-test.js
@@ -2,19 +2,12 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { hasDeprecation, hasNoDeprecations } from '../../helpers/deprecations';
 
 module('Integration | Component | au-toolbar-group', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
-    await render(hbs`<AuToolbarGroup />`);
-
-    assert.dom(this.element).hasText('');
-
-    // Template block usage:
+  test('it renders the block contents', async function (assert) {
     await render(hbs`
       <AuToolbarGroup>
         template block text
@@ -22,5 +15,30 @@ module('Integration | Component | au-toolbar-group', function (hooks) {
     `);
 
     assert.dom(this.element).hasText('template block text');
+  });
+
+  test('it shows a deprecation warning when it is invoked directly', async function (assert) {
+    await render(hbs`
+      <AuToolbarGroup>
+        template block text
+      </AuToolbarGroup>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+    assert.true(
+      hasDeprecation(
+        'Invoking `AuToolbarGroup` directly is deprecated. You should use the component that is yielded from the `AuToolbar` component instead.'
+      )
+    );
+  });
+
+  test("it doesn't show a deprecation warning if the `@wasYielded` arg is set to true", async function (assert) {
+    await render(hbs`
+      <AuToolbarGroup @wasYielded={{true}}>
+        template block text
+      </AuToolbarGroup>
+    `);
+
+    assert.true(hasNoDeprecations());
   });
 });

--- a/tests/integration/components/au-toolbar-test.js
+++ b/tests/integration/components/au-toolbar-test.js
@@ -6,21 +6,23 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | au-toolbar', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
-    await render(hbs`<AuToolbar />`);
-
-    assert.dom(this.element).hasText('');
-
-    // Template block usage:
+  test('it yields a group component', async function (assert) {
     await render(hbs`
-      <AuToolbar>
-        template block text
+      <AuToolbar as |Group|>
+        <Group data-test-foo>Foo</Group>
+        <Group data-test-bar>Bar</Group>
       </AuToolbar>
     `);
 
-    assert.dom(this.element).hasText('template block text');
+    assert.dom('[data-test-foo]').hasText('Foo');
+    assert.dom('[data-test-bar]').hasText('Bar');
+  });
+
+  test('it passes through extra html attributes', async function (assert) {
+    await render(hbs`
+      <AuToolbar data-test-foo="bar"></AuToolbar>
+    `);
+
+    assert.dom('[data-test-foo]').exists();
   });
 });


### PR DESCRIPTION
This yields the `AuToolbarGroup` component from the `AuToolbar` component and deprecates directly invoking it.

Not a breaking change, but it will create _a lot_ of noise since the component is used quite a bit 😄.

Closes #251 