### PR TITLE
Replace `{{prop}}` with a custom modifier

### DIFF
--- a/addon/components/au-date-picker.hbs
+++ b/addon/components/au-date-picker.hbs
@@ -20,8 +20,7 @@
       first-day-of-week={{@first-day}}
       data-test-au-date-picker-component
       {{on "duetChange" this.handleDuetDateChange}}
-      {{prop localization=this.localization}}
-      {{prop dateAdapter=this.adapter}}
+      {{au-props localization=this.localization dateAdapter=this.adapter}}
       ...attributes
     ></duet-date-picker>
   {{/if}}

--- a/addon/modifiers/au-props.js
+++ b/addon/modifiers/au-props.js
@@ -1,0 +1,10 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier(
+  function auProps(element, positional, properties) {
+    for (let propertyName in properties) {
+      element[propertyName] = properties[propertyName];
+    }
+  },
+  { eager: false }
+);

--- a/app/modifiers/au-props.js
+++ b/app/modifiers/au-props.js
@@ -1,0 +1,1 @@
+export { default } from '@appuniversum/ember-appuniversum/modifiers/au-props';

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "ember-file-upload": "^4.0.1",
     "ember-focus-trap": "^1.0.1",
     "ember-inputmask5": "^3.2.0",
+    "ember-modifier": "^3.2.7",
     "ember-named-blocks-polyfill": "^0.2.5",
-    "ember-prop-modifier": "^1.0.1",
     "ember-test-selectors": "^6.0.0",
     "tracked-toolbox": "^1.2.3"
   },

--- a/tests/integration/modifiers/au-props-test.js
+++ b/tests/integration/modifiers/au-props-test.js
@@ -1,0 +1,34 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Modifier | au-props', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it sets values as properties on the DOM element', async function (assert) {
+    this.value = 'bar';
+
+    await render(hbs`<div data-test {{au-props foo=this.value}}></div>`);
+
+    assert.dom('[data-test]').hasProperty('foo', 'bar');
+
+    this.set('value', 'baz');
+    assert
+      .dom('[data-test]')
+      .hasProperty(
+        'foo',
+        'baz',
+        'it updates the property if the value changes'
+      );
+  });
+
+  test('it can set multiple properties at once', async function (assert) {
+    await render(hbs`<div data-test {{au-props foo="bar" baz="qux"}}></div>`);
+
+    assert
+      .dom('[data-test]')
+      .hasProperty('foo', 'bar')
+      .hasProperty('baz', 'qux');
+  });
+});


### PR DESCRIPTION
The ember-prop-modifier addon is no longer maintained so we replace it with a custom modifier for now.

This solves some of the issues in #223 