### PR TITLE
Use hand cursor for actions

### DIFF
--- a/addon/components/au-file-card.hbs
+++ b/addon/components/au-file-card.hbs
@@ -1,8 +1,8 @@
-<article class="au-file-card au-o-box au-o-box--small" ...attributes>
+<article class="au-c-file-card au-o-box au-o-box--small" ...attributes>
   {{#if this.isRemovable}}
     <button
       type="button"
-      class="au-file-card__delete"
+      class="au-c-file-card__delete"
       data-test-file-card-delete
       {{on "click" this.delete}}
     >
@@ -16,7 +16,7 @@
 
     {{#if @fileSize}}
       <span
-        class="au-file-card__file-size"
+        class="au-c-file-card__file-size"
         data-test-file-card-file-size
       >({{@fileSize}})</span>
     {{/if}}

--- a/addon/components/au-time-picker.hbs
+++ b/addon/components/au-time-picker.hbs
@@ -1,9 +1,9 @@
-<div class="au-time-picker" >
-  <div class="au-time-picker__box">
+<div class="au-c-time-picker" >
+  <div class="au-c-time-picker__box">
     <AuLabel for="input-hour" data-test-autimepicker-hourlabel>{{@hoursLabel}}</AuLabel>
-    <div class="au-time-picker__input-wrapper">
+    <div class="au-c-time-picker__input-wrapper">
       <AuInput
-        class="au-time-picker__input"
+        class="au-c-time-picker__input"
         name="input-hour"
         id="input-hour"
         data-test-autimepicker-hourinput
@@ -11,12 +11,12 @@
         {{on 'keyup' (fn this.timeValueKeyPress "hourValue")}}
         {{on 'input' (fn this.validateTime "hourValue")}}
       />
-      <div class="au-time-picker__button-wrapper">
+      <div class="au-c-time-picker__button-wrapper">
         <button
           type="button"
           aria-label="increment hours"
           aria-controls="input-hour"
-          class="au-time-picker__button"
+          class="au-c-time-picker__button"
           data-test-autimepicker-hourincrement
           {{on 'click' (fn this.increment "hourValue")}}>
           +
@@ -25,7 +25,7 @@
           type="button"
           aria-label="decrement hours"
           aria-controls="input-hour"
-          class="au-time-picker__button"
+          class="au-c-time-picker__button"
           data-test-autimepicker-hourdecrement
           {{on 'click' (fn this.decrement "hourValue")}}>
           -
@@ -34,13 +34,13 @@
     </div>
   </div>
 
-  <span class="au-time-picker__separator">:</span>
+  <span class="au-c-time-picker__separator">:</span>
 
-  <div class="au-time-picker__box">
+  <div class="au-c-time-picker__box">
     <AuLabel for="input-minute" data-test-autimepicker-minutelabel>{{@minutesLabel}}</AuLabel>
-    <div class="au-time-picker__input-wrapper">
+    <div class="au-c-time-picker__input-wrapper">
       <AuInput
-        class="au-time-picker__input"
+        class="au-c-time-picker__input"
         name="input-minute"
         id="input-minute"
         data-test-autimepicker-minuteinput
@@ -48,12 +48,12 @@
         {{on 'keyup' (fn this.timeValueKeyPress "minuteValue")}}
         {{on 'input' (fn this.validateTime "minuteValue")}}
       />
-      <div class="au-time-picker__button-wrapper">
+      <div class="au-c-time-picker__button-wrapper">
         <button
           aria-label="increment minutes"
           type="button"
           aria-controls="input-minute"
-          class="au-time-picker__button"
+          class="au-c-time-picker__button"
             data-test-autimepicker-minuteincrement
           {{on 'click' (fn this.increment "minuteValue")}}>
           +
@@ -62,7 +62,7 @@
           aria-label="decrement minutes"
           type="button"
           aria-controls="input-minute"
-          class="au-time-picker__button"
+          class="au-c-time-picker__button"
             data-test-autimepicker-minutedecrement
           {{on 'click' (fn this.decrement "minuteValue")}}>
           -
@@ -72,13 +72,13 @@
   </div>
 
   {{#if this.showSeconds}}
-    <span class="au-time-picker__separator">:</span>
+    <span class="au-c-time-picker__separator">:</span>
 
-    <div class="au-time-picker__box">
+    <div class="au-c-time-picker__box">
       <AuLabel for="input-second" data-test-autimepicker-secondlabel>{{@secondsLabel}}</AuLabel>
-      <div class="au-time-picker__input-wrapper">
+      <div class="au-c-time-picker__input-wrapper">
         <AuInput
-          class="au-time-picker__input"
+          class="au-c-time-picker__input"
           name="input-second"
           id="input-second"
           data-test-autimepicker-secondinput
@@ -86,12 +86,12 @@
           {{on 'keyup' (fn this.timeValueKeyPress "secondValue")}}
           {{on 'input' (fn this.validateTime "secondValue")}}
         />
-        <div class="au-time-picker__button-wrapper">
+        <div class="au-c-time-picker__button-wrapper">
           <button
             aria-label="increment seconds"
             type="button"
             aria-controls="input-second"
-            class="au-time-picker__button"
+            class="au-c-time-picker__button"
             data-test-autimepicker-secondincrement
             {{on 'click' (fn this.increment "secondValue")}}>
             +
@@ -100,7 +100,7 @@
             aria-label="decrement seconds"
             type="button"
             aria-controls="input-second"
-            class="au-time-picker__button"
+            class="au-c-time-picker__button"
             data-test-autimepicker-seconddecrement
             {{on 'click' (fn this.decrement "secondValue")}}>
             -
@@ -111,9 +111,9 @@
   {{/if}}
 
   {{#if this.showNow}}
-    <div class="au-time-picker__box">
+    <div class="au-c-time-picker__box">
       <AuButton
-        class="au-time-picker__current"
+        class="au-c-time-picker__current"
         data-test-autimepicker-nowbutton
         {{on 'click' this.setCurrentTime}}>
         {{@nowLabel}}

--- a/app/styles/ember-appuniversum/_c-alert.scss
+++ b/app/styles/ember-appuniversum/_c-alert.scss
@@ -80,6 +80,7 @@ $au-alert-radius                        : var(--au-radius) !default;
 }
 
 .au-c-alert__close {
+  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/styles/ember-appuniversum/_c-button.scss
+++ b/app/styles/ember-appuniversum/_c-button.scss
@@ -44,6 +44,7 @@ $au-button-alert-contrast-hover-color           : var(--au-red-700) !default;
   cursor: default;
   font-family: var(--au-font);
   font-weight: var(--au-regular);
+  cursor: pointer;
   height: $au-button-height;
   text-decoration: none;
   text-align: center;

--- a/app/styles/ember-appuniversum/_c-dropdown.scss
+++ b/app/styles/ember-appuniversum/_c-dropdown.scss
@@ -77,6 +77,8 @@ $au-dropdown-caret-size        : .4rem !default;
 
 .au-c-dropdown__button {
   @include au-font-size(var(--au-base),1);
+  cursor: pointer;
+
   border: 0;
   padding: 0;
   margin-left: $au-unit-tiny;

--- a/app/styles/ember-appuniversum/_c-dropdown.scss
+++ b/app/styles/ember-appuniversum/_c-dropdown.scss
@@ -78,7 +78,6 @@ $au-dropdown-caret-size        : .4rem !default;
 .au-c-dropdown__button {
   @include au-font-size(var(--au-base),1);
   cursor: pointer;
-
   border: 0;
   padding: 0;
   margin-left: $au-unit-tiny;

--- a/app/styles/ember-appuniversum/_c-file-card.scss
+++ b/app/styles/ember-appuniversum/_c-file-card.scss
@@ -11,14 +11,14 @@ $au-file-card-radius: var(--au-radius) !default;
 /* Component
      ========================================================================== */
 
-.au-file-card {
+.au-c-file-card {
   position: relative;
   background-color: var(--au-white);
   border: 0.1rem solid $au-file-card-border-color;
   border-radius: $au-file-card-radius;
 }
 
-.au-file-card__delete {
+.au-c-file-card__delete {
   position: absolute;
   appearance: none;
   border: 0;
@@ -28,6 +28,7 @@ $au-file-card-radius: var(--au-radius) !default;
   top: $au-unit-small;
   right: $au-unit-small;
   color: var(--au-gray-700);
+  cursor: pointer;
 
   &:hover {
     color: var(--au-gray-600);
@@ -38,7 +39,7 @@ $au-file-card-radius: var(--au-radius) !default;
   }
 }
 
-.au-file-card__file-size {
+.au-c-file-card__file-size {
   color: var(--au-gray-700);
   font-style: italic;
   font-weight: normal;

--- a/app/styles/ember-appuniversum/_c-file-upload.scss
+++ b/app/styles/ember-appuniversum/_c-file-upload.scss
@@ -48,6 +48,7 @@
 
 .au-c-file-upload-label {
   @include au-font-size(var(--au-h5));
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   padding: $au-unit-small $au-unit-small;

--- a/app/styles/ember-appuniversum/_c-modal.scss
+++ b/app/styles/ember-appuniversum/_c-modal.scss
@@ -113,6 +113,7 @@ $au-modal-backdrop-z-index : 9998 !default;
 }
 
 .au-c-modal__close {
+  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/styles/ember-appuniversum/_c-pill.scss
+++ b/app/styles/ember-appuniversum/_c-pill.scss
@@ -81,7 +81,7 @@ $au-pill-gap-small                    : .4rem !default;
   border-radius: $au-unit-tiny;
   min-height: 2.55rem;
   text-decoration: none;
-  cursor: default;
+  cursor: pointer;
 
   &:hover,
   &:focus {

--- a/app/styles/ember-appuniversum/_c-timepicker.scss
+++ b/app/styles/ember-appuniversum/_c-timepicker.scss
@@ -37,6 +37,7 @@
 
 .au-time-picker__button {
   @include au-font-size(1.4rem,1);
+  cursor: pointer;
   flex-grow: 1;
   font-family: var(--au-font);
   font-weight: var(--au-medium);

--- a/app/styles/ember-appuniversum/_c-timepicker.scss
+++ b/app/styles/ember-appuniversum/_c-timepicker.scss
@@ -9,21 +9,21 @@
 /* Component
    ========================================================================== */
 
-.au-time-picker {
+.au-c-time-picker {
   display: flex;
   align-items: flex-end;
 }
 
-.au-time-picker__input-wrapper {
+.au-c-time-picker__input-wrapper {
   position: relative;
 }
 
-.au-time-picker__input {
+.au-c-time-picker__input {
   width: 100%;
   max-width: 8rem;
 }
 
-.au-time-picker__button-wrapper {
+.au-c-time-picker__button-wrapper {
   position: absolute;
   right: 0;
   height: calc(100% - .2rem);
@@ -35,7 +35,7 @@
   border-left: .1rem solid var(--au-gray-300);
 }
 
-.au-time-picker__button {
+.au-c-time-picker__button {
   @include au-font-size(1.4rem,1);
   cursor: pointer;
   flex-grow: 1;
@@ -77,11 +77,11 @@
   }
 }
 
-.au-time-picker__separator {
+.au-c-time-picker__separator {
   font-weight: var(--au-medium);
   padding: $au-unit-tiny;
 }
 
-.au-time-picker__current {
+.au-c-time-picker__current {
   margin-left: $au-unit-small;
 }


### PR DESCRIPTION
For consistency reasons and clarity (after a long discussions and research into current conventions) it was decided to add a hand cursor to all actions (buttons, dropdowns, ...). Some users also reported buttons with a default cursor as a bug.

Additional fix: add component namespace to file card classnames