### PR TITLE
Fix a problem where selecting a PowerSelect option closes the modal

### DIFF
--- a/addon/components/au-modal.hbs
+++ b/addon/components/au-modal.hbs
@@ -1,6 +1,11 @@
 {{#if @modalOpen}}
   {{#in-element this.destinationElement}}
-    <div class="au-c-modal-backdrop {{if @modalOpen "is-visible"}}" data-test-modal-backdrop></div>
+    <div
+      class="au-c-modal-backdrop {{if @modalOpen "is-visible"}}"
+      role="button"
+      data-test-modal-backdrop
+      {{on "click" this.closeModal}}
+    ></div>
     <div id="{{@id}}"
       class={{concat "au-c-modal " this.size this.padding (if @modalOpen " is-visible")}}
       role="dialog"
@@ -11,7 +16,7 @@
           focusTrapOptions=
             (hash
               initialFocus=".au-c-modal__title"
-              allowOutsideClick=this.handleOutsideClick
+              allowOutsideClick=true
               escapeDeactivates=this.handleEscapePress
             )
       }}

--- a/addon/components/au-modal.js
+++ b/addon/components/au-modal.js
@@ -47,14 +47,6 @@ export default class AuModal extends Component {
   }
 
   @action
-  handleOutsideClick() {
-    this.closeModal();
-
-    // allowOutsideClick can be set to false since we handle the closing here already
-    return false;
-  }
-
-  @action
   closeModal() {
     this.args.closeModal?.();
   }

--- a/tests/integration/components/au-modal-test.js
+++ b/tests/integration/components/au-modal-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { selectChoose } from 'ember-power-select/test-support';
 
 const MODAL = {
   ELEMENT: '[data-test-modal]',
@@ -181,6 +182,35 @@ module('Integration | Component | au-modal', function (hooks) {
     let backdrop = document.querySelector(MODAL.BACKDROP);
     await click(backdrop);
     assert.equal(timesCalled, 1);
+  });
+
+  test("it doesn't close the modal when an option in an embedded power-select is clicked", async function (assert) {
+    let timesCalled = 0;
+    this.set('handleClose', () => {
+      timesCalled++;
+      this.set('isOpen', false);
+    });
+
+    this.options = ['foo', 'bar', 'baz'];
+    this.isOpen = true;
+    this.onChange = () => {};
+
+    await render(hbs`
+      <AuModal @modalOpen={{this.isOpen}} @closeModal={{this.handleClose}}>
+        <:body>
+          <PowerSelect
+            @options={{this.options}}
+            @onChange={{this.onChange}}
+            data-test-select
+            as |option|
+          >{{option}}</PowerSelect>
+        </:body>
+      </AuModal>
+    `);
+
+    await selectChoose('[data-test-select]', 'bar');
+
+    assert.equal(timesCalled, 0);
   });
 
   test('it calls @onClose only once when the component is rendered conditionally', async function (assert) {


### PR DESCRIPTION
The previous refactor didn't take into account that embedded components could also be rendered in external elements. Since focus-trap considers these "outside" elements, the modal was closed when clicking on them.

Fixes #282 