### PR TITLE
Fix `AuAlert` deprecations in the `AuFileUpload` component

### DIFF
--- a/addon/components/au-file-upload.hbs
+++ b/addon/components/au-file-upload.hbs
@@ -27,7 +27,7 @@
   {{/if}}
 </FileDropzone>
 {{#if this.hasErrors}}
-  <AuAlert @alertIcon="alert-triangle" @alertskin="error" @alertsize="small" @closable={{true}} class="au-u-margin-top-tiny">
+  <AuAlert @icon="alert-triangle" @skin="error" @size="small" @closable={{true}} class="au-u-margin-top-tiny">
     <ul>
       {{#each this.uploadErrorData as |data|}}
         <li>Fout bij het opladen van {{data.filename}}.


### PR DESCRIPTION
While working on #302 I noticed that we were still using the old argument names which means we would trigger deprecations that consuming applications can't fix themselves 😄.

It seems we missed these during the implementation of the deprecations (#237).