### PR TITLE
Drop node 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: npm
       - name: Install Dependencies
         run: npm ci
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: npm
       - name: Install Dependencies
         run: npm install --no-shrinkwrap
@@ -69,7 +69,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: npm
       - name: Install Dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Compatibility
 
 * Ember.js v3.20 or above
 * Ember CLI v3.20 or above
-* Node.js v12 or above
+* Node.js v14 or above
 
 
 Installation

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "ember-power-select": "2.x || 3.x || 4.x || 5.x"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Node 12 has been EOL since 30/4/2022.

Closes #256 