### PR TITLE
Various small improvements to button component

### DIFF
--- a/addon/components/au-button.hbs
+++ b/addon/components/au-button.hbs
@@ -4,33 +4,26 @@
   ...attributes
 >
   {{#unless this.loading}}
-    {{#if @icon}}
-      {{#if (eq @iconAlignment "left")}}
-      <AuIcon @icon="{{@icon}}" @alignment="left" />
-      {{/if}}
-      {{#unless @iconAlignment}}
+    {{#if (and @icon (eq this.iconAlignment "left"))}}
       <AuIcon @icon="{{@icon}}" />
-      {{/unless}}
     {{/if}}
   {{/unless}}
   {{#if @hideText}}
     {{#if this.loading}}
-    <span class="au-u-hidden-visually">Aan het laden</span><AuLoader @padding="small" />
+      <span class="au-u-hidden-visually">Aan het laden</span><AuLoader @padding="small" />
     {{else}}
-    <span class="au-u-hidden-visually">{{yield}}</span>
+      <span class="au-u-hidden-visually">{{yield}}</span>
     {{/if}}
   {{else}}
     {{#if this.loading}}
-    {{this.loadingMessage}} <AuLoader @padding="small" class="au-u-margin-left-tiny" />
+      {{this.loadingMessage}} <AuLoader @padding="small" />
     {{else}}
-    {{yield}}
+      {{yield}}
     {{/if}}
   {{/if}}
   {{#unless this.loading}}
-    {{#if @icon}}
-      {{#if (eq @iconAlignment "right")}}
-      <AuIcon @icon="{{@icon}}" @alignment="right" />
-      {{/if}}
+    {{#if (and @icon (eq this.iconAlignment "right"))}}
+      <AuIcon @icon="{{@icon}}" />
     {{/if}}
   {{/unless}}
 </button>

--- a/addon/components/au-button.hbs
+++ b/addon/components/au-button.hbs
@@ -1,5 +1,5 @@
 <button
-  class="au-c-button {{this.width}} {{this.size}} {{this.skin}} {{this.alert}} {{this.loading}} {{this.disabled}}" disabled={{@disabled}}
+  class="au-c-button {{this.width}} {{this.size}} {{this.skin}} {{this.alert}} {{this.loading}} {{this.disabled}} {{if (and @icon @hideText) 'au-c-button--icon-only'}}" disabled={{@disabled}}
   type="button"
   ...attributes
 >

--- a/addon/components/au-button.js
+++ b/addon/components/au-button.js
@@ -42,4 +42,9 @@ export default class AuButton extends Component {
     if (this.args.loadingMessage) return this.args.loadingMessage;
     else return 'Aan het laden';
   }
+
+  get iconAlignment() {
+    if (this.args.iconAlignment) return this.args.iconAlignment;
+    else return 'left';
+  }
 }

--- a/app/styles/ember-appuniversum/_c-button.scss
+++ b/app/styles/ember-appuniversum/_c-button.scss
@@ -32,6 +32,10 @@ $au-button-link-active-color                    : var(--au-gray-900) !default;
 $au-button-alert-color                          : var(--au-white) !default;
 $au-button-alert-contrast-color                 : var(--au-red-600) !default;
 $au-button-alert-contrast-hover-color           : var(--au-red-700) !default;
+$au-button-icon-only-width                      : $au-button-height  !default;
+$au-button-icon-only-width-large                : $au-button-height-large  !default;
+$au-button-icon-only-icon-size                  : var(--au-icon-size-medium) !default;
+$au-button-icon-only-icon-size-large            : var(--au-icon-size-large) !default;
 
 
 
@@ -419,6 +423,24 @@ $au-button-alert-contrast-hover-color           : var(--au-red-700) !default;
 .au-c-button--tertiary.is-active {
   color: $au-button-link-active-color;
   font-weight: var(--au-medium);
+}
+
+.au-c-button--icon-only {
+  padding: 0 calc((#{$au-button-icon-only-width - ($au-button-border * 2)} - #{$au-button-icon-only-icon-size}) / 2); // calculate padding automatically to create square icon-only buttons
+
+  .au-c-icon {
+    width: $au-button-icon-only-icon-size;
+    height: $au-button-icon-only-icon-size;
+  }
+}
+
+.au-c-button--icon-only.au-c-button--large {
+  padding: 0 calc((#{$au-button-icon-only-width-large - ($au-button-border * 2)} - #{$au-button-icon-only-icon-size-large}) / 2); // calculate padding automatically to create square icon-only buttons
+
+  .au-c-icon {
+    width: $au-button-icon-only-icon-size-large;
+    height: $au-button-icon-only-icon-size-large;
+  }
 }
 
 /* Animations

--- a/app/styles/ember-appuniversum/_c-button.scss
+++ b/app/styles/ember-appuniversum/_c-button.scss
@@ -41,7 +41,6 @@ $au-button-alert-contrast-hover-color           : var(--au-red-700) !default;
 
 .au-c-button {
   @include au-font-size($au-button-font-size, $au-button-height - $au-button-border * 2);
-  cursor: default;
   font-family: var(--au-font);
   font-weight: var(--au-regular);
   cursor: pointer;

--- a/app/styles/ember-appuniversum/_c-button.scss
+++ b/app/styles/ember-appuniversum/_c-button.scss
@@ -50,6 +50,7 @@ $au-button-alert-contrast-hover-color           : var(--au-red-700) !default;
   text-align: center;
   appearance: none;
   display: inline-flex;
+  gap: $au-unit-tiny;
   align-items: center;
   padding: 0 $au-unit-small; // Visually center the text in the button
   border-radius: $au-button-border-radius;

--- a/app/styles/ember-appuniversum/_c-button.scss
+++ b/app/styles/ember-appuniversum/_c-button.scss
@@ -34,8 +34,6 @@ $au-button-alert-contrast-color                 : var(--au-red-600) !default;
 $au-button-alert-contrast-hover-color           : var(--au-red-700) !default;
 $au-button-icon-only-width                      : $au-button-height  !default;
 $au-button-icon-only-width-large                : $au-button-height-large  !default;
-$au-button-icon-only-icon-size                  : var(--au-icon-size-medium) !default;
-$au-button-icon-only-icon-size-large            : var(--au-icon-size-large) !default;
 
 
 
@@ -426,20 +424,20 @@ $au-button-icon-only-icon-size-large            : var(--au-icon-size-large) !def
 }
 
 .au-c-button--icon-only {
-  padding: 0 calc((#{$au-button-icon-only-width - ($au-button-border * 2)} - #{$au-button-icon-only-icon-size}) / 2); // calculate padding automatically to create square icon-only buttons
+  padding: 0 calc((#{$au-button-icon-only-width - ($au-button-border * 2)} - var(--au-icon-size-medium)) / 2); // calculate padding automatically to create square icon-only buttons
 
   .au-c-icon {
-    width: $au-button-icon-only-icon-size;
-    height: $au-button-icon-only-icon-size;
+    width: var(--au-icon-size-medium);
+    height: var(--au-icon-size-medium);
   }
 }
 
 .au-c-button--icon-only.au-c-button--large {
-  padding: 0 calc((#{$au-button-icon-only-width-large - ($au-button-border * 2)} - #{$au-button-icon-only-icon-size-large}) / 2); // calculate padding automatically to create square icon-only buttons
+  padding: 0 calc((#{$au-button-icon-only-width-large - ($au-button-border * 2)} - var(--au-icon-size-large)) / 2); // calculate padding automatically to create square icon-only buttons
 
   .au-c-icon {
-    width: $au-button-icon-only-icon-size-large;
-    height: $au-button-icon-only-icon-size-large;
+    width: var(--au-icon-size-large);
+    height: var(--au-icon-size-large);
   }
 }
 

--- a/app/styles/ember-appuniversum/_c-icon.scss
+++ b/app/styles/ember-appuniversum/_c-icon.scss
@@ -5,9 +5,9 @@
 /* Variables
    ========================================================================== */
 
-$au-icon-size        : 1.3rem !default;
-$au-icon-size-medium : 1.6rem !default;
-$au-icon-size-large  : 1.9rem !default;
+$au-icon-size        : var(--au-icon-size) !default;
+$au-icon-size-medium : var(--au-icon-size-medium) !default;
+$au-icon-size-large  : var(--au-icon-size-large) !default;
 
 
 /* Component

--- a/app/styles/ember-appuniversum/_s-root.scss
+++ b/app/styles/ember-appuniversum/_s-root.scss
@@ -125,6 +125,11 @@
   --au-h1-medium: 4rem;
   --au-h1: 4.4rem;
 
+  // Icons
+  --au-icon-size: 1.3rem;
+  --au-icon-size-medium: 1.6rem;
+  --au-icon-size-large: 1.9rem;
+
   // UI
   --au-radius: .3rem;
   --au-border: .2rem;

--- a/stories/7-templates/AppLogin.stories.js
+++ b/stories/7-templates/AppLogin.stories.js
@@ -11,8 +11,8 @@ const Template = (args) => ({
   template: hbs`
     <AuApp>
       <AuMainHeader @brandLink="https://www.vlaanderen.be/nl" @homeRoute="docs.templates.app-sidebar" @appTitle="App title" @contactRoute="docs.templates.app-sidebar">
-        <AuButton @skin="tertiary" role="menuitem">
-          <AuIcon @icon="login" @alignment="left" />Aanmelden
+        <AuButton @skin="link" @icon="login" role="menuitem">
+          Aanmelden
         </AuButton>
       </AuMainHeader>
       <AuMainContainer as |m|>

--- a/tests/integration/components/au-button-test.js
+++ b/tests/integration/components/au-button-test.js
@@ -24,18 +24,6 @@ module('Integration | Component | au-button', function (hooks) {
     assert.dom(this.element).hasText('template block text');
   });
 
-  test('it hides the text when @hideText is set to true', async function (assert) {
-    await render(hbs`
-      <AuButton
-        @hideText={{true}}
-      >
-        template block text
-      </AuButton>
-    `);
-
-    assert.dom('.au-u-hidden-visually').exists();
-  });
-
   test('it adds the icon-only modifier class when an icon is defined and @hideText is set to true', async function (assert) {
     await render(hbs`
       <AuButton

--- a/tests/integration/components/au-button-test.js
+++ b/tests/integration/components/au-button-test.js
@@ -23,17 +23,4 @@ module('Integration | Component | au-button', function (hooks) {
 
     assert.dom(this.element).hasText('template block text');
   });
-
-  test('it adds the icon-only modifier class when an icon is defined and @hideText is set to true', async function (assert) {
-    await render(hbs`
-      <AuButton
-        @icon="plus"
-        @hideText={{true}}
-      >
-        template block text
-      </AuButton>
-    `);
-
-    assert.dom('button').hasClass('au-c-button--icon-only');
-  });
 });

--- a/tests/integration/components/au-button-test.js
+++ b/tests/integration/components/au-button-test.js
@@ -23,4 +23,29 @@ module('Integration | Component | au-button', function (hooks) {
 
     assert.dom(this.element).hasText('template block text');
   });
+
+  test('it hides the text when @hideText is set to true', async function (assert) {
+    await render(hbs`
+      <AuButton
+        @hideText={{true}}
+      >
+        template block text
+      </AuButton>
+    `);
+
+    assert.dom('.au-u-hidden-visually').exists();
+  });
+
+  test('it adds the icon-only modifier class when an icon is defined and @hideText is set to true', async function (assert) {
+    await render(hbs`
+      <AuButton
+        @icon="plus"
+        @hideText={{true}}
+      >
+        template block text
+      </AuButton>
+    `);
+
+    assert.dom('button').hasClass('au-c-button--icon-only');
+  });
 });


### PR DESCRIPTION
The following changes should allow easier integration of button component within the Kaleidos (or any) app:
- Switch regarding spacing (inside button) from margins to gap: enables automatic spacing of children + fixes icon-only redundant spacing issue.
- Add `au-c-button--icon-only` class if an icon is defined and @hideText is set to true: allows for additional styling if needed (not applied by default). As used within the link component. E.g. inside the Kaleidos app, we need less horizontal padding on icon-only buttons.

Also added testing to cover the changes mentioned above.