### PR TITLE
Spacing issue (icon + text) link component with button skin

### DIFF
--- a/addon/components/au-file-card.hbs
+++ b/addon/components/au-file-card.hbs
@@ -30,7 +30,7 @@
         download={{@filename}}
         data-test-file-card-download
       >
-        <AuIcon @icon="download" @alignment="left" />
+        <AuIcon @icon="download" />
         Download bestand
       </a>
     </div>

--- a/addon/components/au-link-external.hbs
+++ b/addon/components/au-link-external.hbs
@@ -5,22 +5,15 @@
   href=""
   ...attributes
 >
-  {{#if @icon}}
-    {{#if (eq @iconAlignment "left")}}
-      <AuIcon @icon="{{@icon}}" @alignment="left"/>
-    {{/if}}
-    {{#unless @iconAlignment}}
-      <AuIcon @icon="{{@icon}}"/>
-    {{/unless}}
+  {{#if (and @icon (eq this.iconAlignment "left"))}}
+    <AuIcon @icon="{{@icon}}"/>
   {{/if}}
   {{#if @hideText}}
     <span class="au-u-hidden-visually">{{yield}}</span>
   {{else}}
     {{yield}}
   {{/if}}
-  {{#if @icon}}
-    {{#if (eq @iconAlignment "right")}}
-      <AuIcon @icon="{{@icon}}" @alignment="right"/>
-    {{/if}}
+  {{#if (and @icon (eq this.iconAlignment "right"))}}
+    <AuIcon @icon="{{@icon}}" />
   {{/if}}
 </a>

--- a/addon/components/au-link-external.js
+++ b/addon/components/au-link-external.js
@@ -18,4 +18,9 @@ export default class AuLinkExternal extends Component {
     if (this.args.width == 'block') return 'au-c-link--block';
     else return '';
   }
+
+  get iconAlignment() {
+    if (this.args.iconAlignment) return this.args.iconAlignment;
+    else return 'left';
+  }
 }

--- a/addon/components/au-link.hbs
+++ b/addon/components/au-link.hbs
@@ -5,22 +5,15 @@
   class="{{this.skin}} {{this.active}} {{this.width}} {{if @hideText 'au-c-link--icon-only'}}"
   ...attributes
 >
-  {{#if @icon}}
-    {{#if (eq @iconAlignment "left")}}
-      <AuIcon @icon="{{@icon}}" @alignment="left"/>
-    {{/if}}
-    {{#unless @iconAlignment}}
-      <AuIcon @icon="{{@icon}}"/>
-    {{/unless}}
+  {{#if (and @icon (eq this.iconAlignment "left"))}}
+    <AuIcon @icon="{{@icon}}"/>
   {{/if}}
   {{#if @hideText}}
     <span class="au-u-hidden-visually">{{yield}}</span>
   {{else}}
     {{yield}}
   {{/if}}
-  {{#if @icon}}
-    {{#if (eq @iconAlignment "right")}}
-      <AuIcon @icon="{{@icon}}" @alignment="right"/>
-    {{/if}}
+  {{#if (and @icon (eq this.iconAlignment "right"))}}
+    <AuIcon @icon="{{@icon}}" />
   {{/if}}
 </LinkTo>

--- a/addon/components/au-link.js
+++ b/addon/components/au-link.js
@@ -59,4 +59,9 @@ export default class AuLink extends Component {
     if (this.args.active) return 'is-active';
     else return '';
   }
+
+  get iconAlignment() {
+    if (this.args.iconAlignment) return this.args.iconAlignment;
+    else return 'left';
+  }
 }

--- a/addon/components/au-main-header.hbs
+++ b/addon/components/au-main-header.hbs
@@ -17,8 +17,7 @@
     <ul class="au-c-list-horizontal">
       {{#if @contactRoute}}
       <li class="au-c-list-horizontal__item">
-        <AuLink @route="{{@contactRoute}}" @skin="secondary">
-          <AuIcon @icon="question-circle" @alignment="left" />
+        <AuLink @route="{{@contactRoute}}" @skin="secondary" @icon="question-circle">
           Contacteer ons
         </AuLink>
       </li>

--- a/app/styles/ember-appuniversum/_c-link.scss
+++ b/app/styles/ember-appuniversum/_c-link.scss
@@ -21,6 +21,7 @@ $au-link-secondary-active-color          : var(--au-gray-900) !default;
 
 .au-c-link {
   display: inline-flex;
+  gap: $au-unit-tiny;
   align-items: center;
   font-family: var(--au-font);
   transition: color var(--au-transition), text-decoration var(--au-transition);

--- a/stories/5-components/Links/AuLink.stories.js
+++ b/stories/5-components/Links/AuLink.stories.js
@@ -71,9 +71,9 @@ const Template = (args) => ({
   context: args,
 });
 
-export const Component = Template.bind({});
-Component.args = {
-  text: 'Link',
+export const Primary = Template.bind({});
+Primary.args = {
+  text: 'Primary',
   route: 'index',
   skin: 'primary',
   icon: 'login',
@@ -81,4 +81,61 @@ Component.args = {
   hideText: false,
   width: '',
   active: false,
+};
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  text: 'Secondary',
+  route: 'index',
+  skin: 'secondary',
+  icon: 'login',
+  iconAlignment: 'left',
+  hideText: false,
+  width: '',
+  active: false,
+};
+Secondary.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
+export const PrimaryButton = Template.bind({});
+PrimaryButton.args = {
+  text: 'Primary Button',
+  route: 'index',
+  skin: 'button',
+  icon: 'login',
+  iconAlignment: 'left',
+  hideText: false,
+  width: '',
+  active: false,
+};
+
+export const SecondaryButton = Template.bind({});
+SecondaryButton.args = {
+  text: 'Secondary Button',
+  route: 'index',
+  skin: 'button-secondary',
+  icon: 'login',
+  iconAlignment: 'left',
+  hideText: false,
+  width: '',
+  active: false,
+};
+SecondaryButton.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
+export const NakedButton = Template.bind({});
+NakedButton.args = {
+  text: 'Naked Button',
+  route: 'index',
+  skin: 'button-naked',
+  icon: 'login',
+  iconAlignment: 'left',
+  hideText: false,
+  width: '',
+  active: false,
+};
+NakedButton.parameters = {
+  chromatic: { disableSnapshot: true },
 };

--- a/stories/7-templates/AppBreadcrumbs.stories.js
+++ b/stories/7-templates/AppBreadcrumbs.stories.js
@@ -21,8 +21,7 @@ const Template = (args) => ({
         <Group>
           <ul class="au-c-list-horizontal au-c-list-horizontal--small">
             <li class="au-c-list-horizontal__item">
-              <AuLink @linkRoute="index">
-                <AuIcon @icon="arrow-left" @alignment="left" />
+              <AuLink @linkRoute="index" @icon="arrow-left">
                 Overzicht modules
               </AuLink>
             </li>

--- a/stories/7-templates/AppEditor.stories.js
+++ b/stories/7-templates/AppEditor.stories.js
@@ -14,8 +14,7 @@ const Template = (args) => ({
         <div class="au-c-app-chrome">
           <AuToolbar @size="small" class="au-u-padding-bottom-none" as |Group|>
             <Group>
-              <AuLink @route="docs.templates.app-editor" @skin="secondary">
-                <AuIcon @icon="arrow-left" @alignment="left" />
+              <AuLink @route="docs.templates.app-editor" @skin="secondary" @icon="arrow-left">
                 Terug naar overzicht agendapunten
               </AuLink>
               <span class="au-c-app-chrome__entity">Title</span>
@@ -33,8 +32,7 @@ const Template = (args) => ({
           <AuToolbar @size="small" class="au-u-padding-top-none" as |Group|>
             <Group>
               <div>
-                <AuPill @skin="warning">
-                  <AuIcon @icon="alert-triangle" @alignment="left" />
+                <AuPill @skin="warning" @icon="alert-triangle">
                   Concept niet bewaard
                 </AuPill>
               </div>


### PR DESCRIPTION
The changes within https://github.com/appuniversum/ember-appuniversum/pull/313 caused an unintended issue: when the AuLink component is displayed with either a `button`, `button-secondary` or `button-naked` skin there is additional whitespace between the icon and the text.

![image](https://user-images.githubusercontent.com/18174827/189352938-5838b0a3-f427-453e-8882-6b8995d7ecc7.png)

Preview URL: https://appuniversum.github.io/ember-appuniversum/?path=/story/components-links-aulink--component&args=skin:button

This issue was not directly caught because the AuLink component with a button-like skin is currently not covered by the Chromatic tests.

The changes I made:
- Performed the same structural (& functional) changes on AuLink and AuLinkExternal made within the AuButton component (see: https://github.com/appuniversum/ember-appuniversum/pull/313/files#diff-08dd95d3f03a9928ab26dce9607419e9c22e141e50a28e916ba9592ac5ca1713).
- Enabled gap spacing within AuLink styling.
- Added stories for AuLink similar to AuButton (so it is covered by Chromatic tests).


