### PR TITLE
AuDropdown refactoring

### DIFF
--- a/addon/components/au-dropdown.hbs
+++ b/addon/components/au-dropdown.hbs
@@ -1,5 +1,4 @@
 <div class="au-c-dropdown" ...attributes>
-  {{#if this.dropdownOpen}}
   <AuButton
     @skin={{this.skin}}
     @size={{@size}}
@@ -8,29 +7,29 @@
     @hideText={{@hideText}}
     @alert={{@alert}}
     aria-haspopup="true"
-    aria-expanded="{{if this.dropdownOpen "true" "false"}}" type="button"
-    {{on "click" this.closeDropdown}} data-test-dropdown-button>
+    aria-expanded="{{if this.dropdownOpen 'true' 'false'}}"
+    type="button"
+    {{on "click" this.toggleDropdown}}
+    data-test-dropdown-button
+    data-au-dropdown-toggle
+  >
     <span class="au-c-dropdown__name" data-test-dropdown-title>
       {{this.title}}
     </span>
   </AuButton>
-  {{else}}
-  <AuButton
-    @skin={{this.skin}}
-    @size={{@size}}
-    @icon={{this.icon}}
-    @iconAlignment={{this.iconAlignment}}
-    @hideText={{@hideText}}
-    @alert={{@alert}}
-    aria-haspopup="true"
-    aria-expanded="{{if this.dropdownOpen "true" "false"}}" type="button"
-    {{on "click" this.openDropdown}} data-test-dropdown-button>
-    <span class="au-c-dropdown__name" data-test-dropdown-title>
-      {{this.title}}
-    </span>
-  </AuButton>
-  {{/if}}
-  <div class="au-c-dropdown__menu {{this.alignment}} {{if this.dropdownOpen "is-visible" ""}}" role="menu" tabindex="-1" {{focus-trap isActive=this.dropdownOpen shouldSelfFocus=true focusTrapOptions=(hash onPostDeactivate=this.closeDropdown clickOutsideDeactivates=true)}} {{on "click" this.closeDropdown}}>
+  <div
+    class="au-c-dropdown__menu {{this.alignment}} {{if this.dropdownOpen 'is-visible'}}"
+    role="menu"
+    tabindex="-1"
+    {{focus-trap
+      isActive=this.dropdownOpen
+      shouldSelfFocus=true
+      focusTrapOptions=(hash
+        clickOutsideDeactivates=this.clickOutsideDeactivates
+      )
+    }}
+    {{on "click" this.closeDropdown}}
+  >
     {{yield}}
   </div>
 </div>

--- a/addon/components/au-dropdown.js
+++ b/addon/components/au-dropdown.js
@@ -16,6 +16,23 @@ export default class AuDropdown extends Component {
     this.dropdownOpen = false;
   }
 
+  @action
+  toggleDropdown() {
+    this.dropdownOpen = !this.dropdownOpen;
+  }
+
+  @action
+  clickOutsideDeactivates(event) {
+    let toggleButton = document.querySelector('[data-au-dropdown-toggle]');
+    let isClosedByToggleButton = toggleButton.contains(event.target);
+
+    if (!isClosedByToggleButton) {
+      this.closeDropdown();
+    }
+
+    return true;
+  }
+
   get title() {
     if (this.args.dropdownTitle) {
       deprecate('@dropdownTitle is deprecated, use @title instead', false, {

--- a/tests/integration/components/au-dropdown-test.js
+++ b/tests/integration/components/au-dropdown-test.js
@@ -37,4 +37,26 @@ module('Integration | Component | au-dropdown', function (hooks) {
         'it closes when clicking the button while the dropdown is open'
       );
   });
+
+  test('it toggles the visibility of its content when clicking children of the dropdown button', async function (assert) {
+    await render(hbs`
+      <AuDropdown @title="foo">
+        <button type="button" data-test-button>baz</button>
+      </AuDropdown>
+    `);
+
+    assert.dom('[data-test-button]').isNotVisible('it is closed by default');
+
+    await click('[data-test-dropdown-button] *');
+    assert
+      .dom('[data-test-button]')
+      .isVisible('it opens after clicking a child of the button');
+
+    await click('[data-test-dropdown-button] *');
+    assert
+      .dom('[data-test-button]')
+      .isNotVisible(
+        'it closes when clicking a child of the button button while the dropdown is open'
+      );
+  });
 });


### PR DESCRIPTION
This removes the duplicated AuButton. We now use focus-trap's clickOutsideDeactivates event to detect when an outside click happened, and only call the close method if the target element is not the toggle button. This prevents the dropdown from instantly reopening again. The previous implementation worked around this by rerendering a different button component which meant the click event was ignored.