### PR TITLE
Various class issues within button & link component

### DIFF
--- a/addon/components/au-button.hbs
+++ b/addon/components/au-button.hbs
@@ -1,27 +1,27 @@
 <button
-  class="au-c-button {{this.width}} {{this.size}} {{this.skin}} {{this.alert}} {{this.loading}} {{this.disabled}} {{if (and @icon @hideText) 'au-c-button--icon-only'}} {{if @wrap 'au-c-button--wrap'}}" disabled={{@disabled}}
+  class="au-c-button {{this.widthClass}} {{this.sizeClass}} {{this.skinClass}} {{this.alertClass}} {{this.loadingClass}} {{this.disabledClass}} {{this.iconOnlyClass}} {{if @wrap 'au-c-button--wrap'}}" disabled={{@disabled}}
   type="button"
   ...attributes
 >
-  {{#unless this.loading}}
+  {{#unless @loading}}
     {{#if (and @icon (eq this.iconAlignment "left"))}}
       <AuIcon @icon="{{@icon}}" />
     {{/if}}
   {{/unless}}
   {{#if @hideText}}
-    {{#if this.loading}}
+    {{#if @loading}}
       <span class="au-u-hidden-visually">Aan het laden</span><AuLoader @padding="small" />
     {{else}}
       <span class="au-u-hidden-visually">{{yield}}</span>
     {{/if}}
   {{else}}
-    {{#if this.loading}}
+    {{#if @loading}}
       {{this.loadingMessage}} <AuLoader @padding="small" />
     {{else}}
       {{yield}}
     {{/if}}
   {{/if}}
-  {{#unless this.loading}}
+  {{#unless @loading}}
     {{#if (and @icon (eq this.iconAlignment "right"))}}
       <AuIcon @icon="{{@icon}}" />
     {{/if}}

--- a/addon/components/au-button.js
+++ b/addon/components/au-button.js
@@ -3,13 +3,10 @@ import Component from '@glimmer/component';
 const SKINS = ['primary', 'secondary', 'naked', 'link', 'link-secondary'];
 
 export default class AuButton extends Component {
-  constructor() {
-    super(...arguments);
-
-    this.skin =
-      this.args.skin === 'tertiary' // DEPRECATED
-        ? 'link'
-        : (SKINS.includes(this.args.skin) ? this.args.skin : 'primary'); // eslint-disable-line prettier/prettier
+  get skin() {
+    if (SKINS.includes(this.args.skin)) return this.args.skin;
+    else if (this.args.skin === 'tertiary') return 'link'; // DEPRECATED
+    else return 'primary';
   }
 
   get sizeClass() {

--- a/addon/components/au-button.js
+++ b/addon/components/au-button.js
@@ -1,39 +1,44 @@
 import Component from '@glimmer/component';
 
+const SKINS = ['primary', 'secondary', 'naked', 'link', 'link-secondary'];
+
 export default class AuButton extends Component {
-  get size() {
-    if (this.args.size == 'large') return 'au-c-button--large';
+  constructor() {
+    super(...arguments);
+
+    this.skin = SKINS.includes(this.args.skin)
+      ? this.args.skin == 'tertiary' // DEPRECATED
+        ? 'link'
+        : this.args.skin
+      : 'primary';
+  }
+
+  get sizeClass() {
+    if (this.args.size == 'large' && !this.skin.startsWith('link'))
+      return 'au-c-button--large';
     else return '';
   }
 
-  get width() {
+  get widthClass() {
     if (this.args.width == 'block') return 'au-c-button--block';
     else return '';
   }
 
-  get skin() {
-    if (this.args.skin == 'secondary') return 'au-c-button--secondary';
-    if (this.args.skin == 'naked') return 'au-c-button--naked';
-    if (this.args.skin == 'tertiary')
-      // DEPRECATED
-      return 'au-c-button--link';
-    if (this.args.skin == 'link') return 'au-c-button--link';
-    if (this.args.skin == 'link-secondary')
-      return 'au-c-button--link-secondary';
-    else return 'au-c-button--primary';
+  get skinClass() {
+    return `au-c-button--${this.skin}`;
   }
 
-  get alert() {
+  get alertClass() {
     if (this.args.alert) return 'au-c-button--alert';
     else return '';
   }
 
-  get disabled() {
+  get disabledClass() {
     if (this.args.disabled) return 'is-disabled';
     else return '';
   }
 
-  get loading() {
+  get loadingClass() {
     if (this.args.loading) return 'is-loading';
     else return '';
   }
@@ -46,5 +51,10 @@ export default class AuButton extends Component {
   get iconAlignment() {
     if (this.args.iconAlignment) return this.args.iconAlignment;
     else return 'left';
+  }
+
+  get iconOnlyClass() {
+    if (this.args.icon && this.args.hideText) return 'au-c-button--icon-only';
+    return '';
   }
 }

--- a/addon/components/au-button.js
+++ b/addon/components/au-button.js
@@ -6,11 +6,10 @@ export default class AuButton extends Component {
   constructor() {
     super(...arguments);
 
-    this.skin = SKINS.includes(this.args.skin)
-      ? this.args.skin == 'tertiary' // DEPRECATED
+    this.skin =
+      this.args.skin === 'tertiary' // DEPRECATED
         ? 'link'
-        : this.args.skin
-      : 'primary';
+        : (SKINS.includes(this.args.skin) ? this.args.skin : 'primary'); // eslint-disable-line prettier/prettier
   }
 
   get sizeClass() {

--- a/addon/components/au-link.hbs
+++ b/addon/components/au-link.hbs
@@ -2,7 +2,7 @@
   @route={{this.route}}
   @models={{au-link-to-models @model @models}}
   @query={{this.queryParams}}
-  class="{{this.skin}} {{this.active}} {{this.width}} {{if @hideText 'au-c-link--icon-only'}}"
+  class="{{this.skinClass}} {{this.activeClass}} {{this.widthClass}} {{this.iconOnlyClass}}"
   ...attributes
 >
   {{#if (and @icon (eq this.iconAlignment "left"))}}

--- a/addon/components/au-link.js
+++ b/addon/components/au-link.js
@@ -29,7 +29,7 @@ export default class AuLink extends Component {
     }
   }
 
-  get skin() {
+  get skinClass() {
     if (SKIN_CLASSES[this.args.skin]) {
       return SKIN_CLASSES[this.args.skin];
     } else {
@@ -37,11 +37,15 @@ export default class AuLink extends Component {
     }
   }
 
-  get width() {
+  get widthClass() {
     if (this.args.width == 'block')
-      if ((this.args.skin == 'button') | 'button-secondary')
-        return 'au-c-button--block';
+      if (this.args.skin.startsWith('button')) return 'au-c-button--block';
       else return 'au-c-link--block';
+    else return '';
+  }
+
+  get activeClass() {
+    if (this.args.active) return 'is-active';
     else return '';
   }
 
@@ -55,13 +59,15 @@ export default class AuLink extends Component {
     }
   }
 
-  get active() {
-    if (this.args.active) return 'is-active';
-    else return '';
-  }
-
   get iconAlignment() {
     if (this.args.iconAlignment) return this.args.iconAlignment;
     else return 'left';
+  }
+
+  get iconOnlyClass() {
+    if (this.args.icon && this.args.hideText)
+      if (this.args.skin.startsWith('button')) return 'au-c-button--icon-only';
+      else return 'au-c-link--icon-only';
+    return '';
   }
 }

--- a/addon/components/au-link.js
+++ b/addon/components/au-link.js
@@ -66,7 +66,8 @@ export default class AuLink extends Component {
 
   get iconOnlyClass() {
     if (this.args.icon && this.args.hideText)
-      if (this.args.skin.startsWith('button')) return 'au-c-button--icon-only';
+      if (this.args.skin && this.args.skin.startsWith('button'))
+        return 'au-c-button--icon-only';
       else return 'au-c-link--icon-only';
     return '';
   }

--- a/app/styles/ember-appuniversum/_c-button.scss
+++ b/app/styles/ember-appuniversum/_c-button.scss
@@ -34,6 +34,7 @@ $au-button-alert-contrast-color                 : var(--au-red-600) !default;
 $au-button-alert-contrast-hover-color           : var(--au-red-700) !default;
 $au-button-icon-only-width                      : $au-button-height  !default;
 $au-button-icon-only-width-large                : $au-button-height-large  !default;
+$au-button-link-icon-only-width                 : $au-button-link-height  !default;
 
 
 
@@ -432,6 +433,11 @@ $au-button-icon-only-width-large                : $au-button-height-large  !defa
 
 .au-c-button--icon-only {
   padding: 0 calc((#{$au-button-icon-only-width - ($au-button-border * 2)} - var(--au-icon-size-medium)) / 2); // calculate padding automatically to create square icon-only buttons
+
+  &.au-c-button--link,
+  &.au-c-button--tertiary {
+    padding: 0 calc((#{$au-button-link-icon-only-width - ($au-button-border * 2)} - var(--au-icon-size-medium)) / 2);
+  }
 
   .au-c-icon {
     width: var(--au-icon-size-medium);


### PR DESCRIPTION
The following class-related issues persist within the `AuButton` & `AuLink` component.

`AuButton`
- When defining an icon & enabling the `hideText` property on a button with a `link` or `link-secondary` skin, the button lacks the correct styling (see screenshot below).
- When setting the size property to `large` on a button with a `link` or `link-secondary` skin (which should not be a possibility at the moment), the component gets a unnecessary `au-c-button--large` class that could cause unintended styling issues in the future.

<img width="68" alt="CleanShot 2022-10-05 at 14 06 57@2x" src="https://user-images.githubusercontent.com/18174827/194056712-d30d9c8e-7a2a-4597-ac6f-e540d63ca465.png">

`AuLink`
- When defining an icon & enabling the `hideText` property on a link with a `button`, `button-secondary` or `button-naked` skin, the link lacks the correct icon-only class (see screenshot below).
- When the component checks internally what specific width-class needs to be applied, there is an invalid check for `button-secondary`. 

<img width="69" alt="CleanShot 2022-10-05 at 14 08 54@2x" src="https://user-images.githubusercontent.com/18174827/194056996-4836aa83-6c8b-4551-8b9c-10ef78104282.png">

Besides that I also:
- Fixed the loading-check within the button component from `this.loading` (used the be a class string) to `@loading`.
- Adjusted the structure (regarding the button skin) a bit so it's more logical & reusable.
- Renamed the class-related getters for both `AuButton` & `AuLink` so that the name reflects the purpose better.