### PR TITLE
Faulty vertical alignment of button & link components

### DIFF
--- a/app/styles/ember-appuniversum/_c-button.scss
+++ b/app/styles/ember-appuniversum/_c-button.scss
@@ -53,7 +53,7 @@ $au-button-icon-only-width-large                : $au-button-height-large  !defa
   display: inline-flex;
   gap: $au-unit-tiny;
   align-items: center;
-  vertical-align: middle;
+  vertical-align: top;
   padding: 0 $au-unit-small; // Visually center the text in the button
   border-radius: $au-button-border-radius;
   white-space: nowrap;

--- a/app/styles/ember-appuniversum/_c-button.scss
+++ b/app/styles/ember-appuniversum/_c-button.scss
@@ -53,6 +53,7 @@ $au-button-icon-only-width-large                : $au-button-height-large  !defa
   display: inline-flex;
   gap: $au-unit-tiny;
   align-items: center;
+  vertical-align: middle;
   padding: 0 $au-unit-small; // Visually center the text in the button
   border-radius: $au-button-border-radius;
   white-space: nowrap;

--- a/app/styles/ember-appuniversum/_c-link.scss
+++ b/app/styles/ember-appuniversum/_c-link.scss
@@ -23,7 +23,7 @@ $au-link-secondary-active-color          : var(--au-gray-900) !default;
   display: inline-flex;
   gap: $au-unit-tiny;
   align-items: center;
-  vertical-align: middle;
+  vertical-align: top;
   font-family: var(--au-font);
   transition: color var(--au-transition), text-decoration var(--au-transition);
   font-weight: var(--au-regular);

--- a/app/styles/ember-appuniversum/_c-link.scss
+++ b/app/styles/ember-appuniversum/_c-link.scss
@@ -23,6 +23,7 @@ $au-link-secondary-active-color          : var(--au-gray-900) !default;
   display: inline-flex;
   gap: $au-unit-tiny;
   align-items: center;
+  vertical-align: middle;
   font-family: var(--au-font);
   transition: color var(--au-transition), text-decoration var(--au-transition);
   font-weight: var(--au-regular);


### PR DESCRIPTION
The following issue is visible when two or more successive `AuButton` or `AuLink` components with one having an icon with left alignment and the other having an icon with left alignment (or even no icon) are displayed: the elements will be vertically aligned in an incorrect way (see screenshot below).

<img width="167" alt="CleanShot 2022-09-14 at 14 31 43@2x" src="https://user-images.githubusercontent.com/18174827/194173852-551a93ac-8c06-44d2-955e-4928a35a6027.png">
