### PR TITLE
Small spacing improvement to control components

### DIFF
--- a/app/styles/ember-appuniversum/_c-control.scss
+++ b/app/styles/ember-appuniversum/_c-control.scss
@@ -14,6 +14,7 @@ $au-control-disabled-color            : var(--au-gray-600) !default;
 .au-c-control {
   position: relative;
   display: inline-flex;
+  gap: $au-unit-tiny;
   color: var(--au-gray-900);
   cursor: pointer;
 }
@@ -39,7 +40,6 @@ $au-control-disabled-color            : var(--au-gray-600) !default;
   background-repeat: no-repeat;
   user-select: none;
   border: .1rem solid var(--au-gray-300);
-  margin-right: $au-unit-tiny;
   margin-top: $au-unit-tiny*.5;
 }
 


### PR DESCRIPTION
The following small change should allow easier integration of control components within the Kaleidos (or any) app:

- Switch regarding spacing (inside control components like checkbox & radio) from margins to gap: enables automatic spacing of children.