### PR TITLE
Update ember-inputmask5 to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16146,15 +16146,13 @@
       }
     },
     "ember-inputmask5": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ember-inputmask5/-/ember-inputmask5-3.2.0.tgz",
-      "integrity": "sha512-rtX82XIr3Cr6+/m2OZk3ENRsb5P5g1YpMapBuukxAC8oewjfxORcXI9ze0J/7YqtuPhG4WeYvYUO079Q0eUG+A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ember-inputmask5/-/ember-inputmask5-4.0.2.tgz",
+      "integrity": "sha512-rPDSsT0wXht21oWB0F9mrZODjpLydMOdcU3oj6zdMWedstp/Ds+5bAabgUqSWAxVRayjbfxYC+AAaOwoy4dyIQ==",
       "requires": {
         "@ember/render-modifiers": "^2.0.4",
-        "ember-auto-import": "^2.4.0",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.0.1",
-        "ember-modifier": "^3.1.0",
+        "@embroider/addon-shim": "^1.8.3",
+        "ember-modifier": "^3.2.7",
         "inputmask": "^5.0.7"
       }
     },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-data-table": "^2.1.0",
     "ember-file-upload": "^4.0.1",
     "ember-focus-trap": "^1.0.1",
-    "ember-inputmask5": "^3.2.0",
+    "ember-inputmask5": "^4.0.2",
     "ember-modifier": "^3.2.7",
     "ember-named-blocks-polyfill": "^0.2.5",
     "ember-test-selectors": "^6.0.0",


### PR DESCRIPTION
This resolves the ember-modifier deprecation messages.

Closes #223 