### PR TITLE
Use Github Actions to publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: 'Publish to npm'
+on:
+  push:
+    tags:
+       - "v*.*.*"
+
+jobs:
+  publish:
+    name: 'Publish'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 12.x
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -155,6 +155,9 @@
     "github": {
       "release": true,
       "tokenRef": "GITHUB_AUTH"
+    },
+    "npm": {
+      "publish": false
     }
   },
   "volta": {


### PR DESCRIPTION
Publishing from CI has the advantage that everyone with write permissions to the repo can release a new version without having to have npm rights to the package.

Closes #219 