### PR TITLE
Addition of support for block content within checkbox component

### DIFF
--- a/addon/components/au-control-checkbox.hbs
+++ b/addon/components/au-control-checkbox.hbs
@@ -13,5 +13,9 @@
     ...attributes
   />
   <span class="au-c-control__indicator"></span>
-  {{@label}}
+  {{#if (has-block)}}
+    {{yield}}
+  {{else}}
+    {{@label}}
+  {{/if}}
 </label>

--- a/tests/integration/components/au-control-checkbox-test.js
+++ b/tests/integration/components/au-control-checkbox-test.js
@@ -19,6 +19,16 @@ module('Integration | Component | au-control-checkbox', function (hooks) {
     assert.dom().hasText('foo');
   });
 
+  test('it can show block content', async function (assert) {
+    await render(hbs`<AuControlCheckbox>bar</AuControlCheckbox>`);
+    assert.dom().hasText('bar');
+  });
+
+  test('it will give preference to show block content against a label', async function (assert) {
+    await render(hbs`<AuControlCheckbox @label="foo">bar</AuControlCheckbox>`);
+    assert.dom().hasText('bar');
+  });
+
   test('it can be disabled', async function (assert) {
     this.disabled = true;
 


### PR DESCRIPTION
The addition of support for block content within the `au-control-checkbox` component.

The reason for this is mostly cases like this within Kaleidos:

![CleanShot 2022-11-21 at 11 25 13](https://user-images.githubusercontent.com/18174827/203028506-5d6ffb6e-6d1f-498a-875e-f4ad602f46a1.png)
