### PR TITLE
Improvement of solo (label-less) control (checkbox & radio) components

### DIFF
--- a/addon/components/au-control-checkbox.hbs
+++ b/addon/components/au-control-checkbox.hbs
@@ -1,6 +1,6 @@
 <label
   for={{@identifier}}
-  class="au-c-control au-c-control--checkbox {{this.disabled}}"
+  class="au-c-control au-c-control--checkbox {{this.disabledClass}} {{if (and (not (has-block)) (not @label)) 'au-c-control--labelless'}}"
 >
   <input
     class="au-c-control__input"

--- a/addon/components/au-control-checkbox.js
+++ b/addon/components/au-control-checkbox.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class AuControlCheckbox extends Component {
-  get disabled() {
+  get disabledClass() {
     if (this.args.disabled) return 'is-disabled';
     else return '';
   }

--- a/addon/components/au-control-radio.hbs
+++ b/addon/components/au-control-radio.hbs
@@ -1,4 +1,4 @@
-<label for="{{@identifier}}" class="au-c-control au-c-control--radio {{this.disabled}}">
+<label for="{{@identifier}}" class="au-c-control au-c-control--radio {{this.disabledClass}} {{unless @label 'au-c-control--labelless'}}">
   <input name="{{@name}}" id="{{@identifier}}" value="{{@value}}" disabled={{@disabled}} type="radio" class="au-c-control__input" {{on "change" this.onChange}} ...attributes>
   <span class="au-c-control__indicator"></span>
   {{@label}}

--- a/addon/components/au-control-radio.js
+++ b/addon/components/au-control-radio.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class AuControlRadio extends Component {
-  get disabled() {
+  get disabledClass() {
     if (this.args.disabled) return 'is-disabled';
     else return '';
   }

--- a/app/styles/ember-appuniversum/_c-control.scss
+++ b/app/styles/ember-appuniversum/_c-control.scss
@@ -63,6 +63,15 @@ $au-control-disabled-color            : var(--au-gray-600) !default;
   border-color: var(--au-blue-700);
 }
 
+/* Labelless modifiers */
+.au-c-control--labelless {
+  vertical-align: middle;
+
+  .au-c-control__indicator {
+    margin-top: 0;
+  }
+}
+
 /* Checkbox modifiers */
 .au-c-control--checkbox .au-c-control__indicator {
   border-radius: .25rem;


### PR DESCRIPTION
When implementing the `AucontrolCheckbox` component within Kaleidos I encountered the following alignment issue:

![CleanShot 2022-11-22 at 21 36 27@2x](https://user-images.githubusercontent.com/18174827/209324143-7c31576e-7ca6-4ec0-9aea-ebdb612d59c9.png)

It seems like solo (without a label) control components (like `AucontrolCheckbox` & `AucontrolRadio`) are not aligned properly.

The adjustments in this PR fixes this issue for both `AucontrolCheckbox` & `AucontrolRadio`:

(the label-less version of both control components can be viewed inside the table I temporarily added locally)

<img width="282" alt="CleanShot 2022-12-23 at 11 41 12@2x" src="https://user-images.githubusercontent.com/18174827/209325261-02528353-d4c1-4d25-a77b-6e826995e596.png">
<img width="282" alt="CleanShot 2022-12-23 at 11 40 13@2x" src="https://user-images.githubusercontent.com/18174827/209325263-11430c89-c7d3-464c-aa45-5def26abd067.png">
