### PR TITLE
Replace the `hasNoDeprecations` test util

### DIFF
--- a/tests/helpers/deprecations.js
+++ b/tests/helpers/deprecations.js
@@ -1,9 +1,5 @@
 import { getDeprecations } from '@ember/test-helpers';
 
-export function hasNoDeprecations() {
-  return getDeprecations().length === 0;
-}
-
 export function hasDeprecation(deprecationMessage) {
   return getDeprecations().some(
     (deprecation) => deprecation.message === deprecationMessage

--- a/tests/integration/components/au-date-picker-test.js
+++ b/tests/integration/components/au-date-picker-test.js
@@ -3,10 +3,7 @@ import { getConfig, getOwnConfig } from '@embroider/macros';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import {
-  hasDeprecationStartingWith,
-  hasNoDeprecations,
-} from '../../helpers/deprecations';
+import { hasDeprecationStartingWith } from '../../helpers/deprecations';
 
 /** @type import("qunit-dom").module */
 module('Integration | Component | au-date-picker', function (hooks) {
@@ -150,7 +147,11 @@ module('Integration | Component | au-date-picker', function (hooks) {
     `);
       await webComponentRender();
 
-      assert.true(hasNoDeprecations());
+      assert.false(
+        hasDeprecationStartingWith(
+          '[AuDatePicker] The English localization is deprecated.'
+        )
+      );
     });
   } else {
     test("it shows a deprecation message if the Dutch localization isn't enabled", async function (assert) {


### PR DESCRIPTION
This util causes tests to fail if other code unrelated to the code being tested also triggers a deprecation. The better solution is to use the `hasDeprecation` or `hasDeprecationStartingWith` utils and expect them to be false.

This should fix the failing ember-canary scenario.