### PR TITLE
Make the au-link-to-models helper truly private

### DIFF
--- a/addon/components/au-link.hbs
+++ b/addon/components/au-link.hbs
@@ -1,6 +1,6 @@
 <LinkTo
   @route={{@route}}
-  @models={{au-link-to-models @model @models}}
+  @models={{this.linkToModels @model @models}}
   @query={{this.queryParams}}
   class="{{this.skinClass}} {{this.activeClass}} {{this.widthClass}} {{this.iconOnlyClass}}"
   ...attributes

--- a/addon/components/au-link.js
+++ b/addon/components/au-link.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import linkToModels from '@appuniversum/ember-appuniversum/private/helpers/link-to-models';
 
 const SKIN_CLASSES = {
   primary: 'au-c-link',
@@ -9,6 +10,8 @@ const SKIN_CLASSES = {
 };
 
 export default class AuLink extends Component {
+  linkToModels = linkToModels;
+
   get skinClass() {
     if (SKIN_CLASSES[this.args.skin]) {
       return SKIN_CLASSES[this.args.skin];

--- a/addon/components/au-navigation-link.hbs
+++ b/addon/components/au-navigation-link.hbs
@@ -1,6 +1,6 @@
 <LinkTo
   @route={{@route}}
-  @models={{au-link-to-models @model @models}}
+  @models={{this.linkToModels @model @models}}
   @query={{this.queryParams}}
   class="au-c-list-navigation__link" ...attributes
   {{on "click" this.linkFocus}}

--- a/addon/components/au-navigation-link.js
+++ b/addon/components/au-navigation-link.js
@@ -1,7 +1,10 @@
+import linkToModels from '@appuniversum/ember-appuniversum/private/helpers/link-to-models';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class AuNavigationLink extends Component {
+  linkToModels = linkToModels;
+
   // this is a workaround for https://github.com/emberjs/ember.js/issues/19693
   // don't remove until we drop support for ember 3.27 and 3.28
   get queryParams() {

--- a/addon/components/au-pill.hbs
+++ b/addon/components/au-pill.hbs
@@ -27,7 +27,7 @@
   <LinkTo
     class="au-c-pill au-c-pill--link {{this.size}} {{this.draft}}"
     @route={{@route}}
-    @models={{au-link-to-models @model @models}}
+    @models={{this.linkToModels @model @models}}
     @query={{this.queryParams}}
     ...attributes>
     {{#if @icon}}

--- a/addon/components/au-pill.js
+++ b/addon/components/au-pill.js
@@ -1,8 +1,11 @@
+import linkToModels from '@appuniversum/ember-appuniversum/private/helpers/link-to-models';
 import Component from '@glimmer/component';
 
 const PILL_SIZES = ['small'];
 
 export default class AuPillComponent extends Component {
+  linkToModels = linkToModels;
+
   get skin() {
     if (this.args.skin == 'border') return 'au-c-pill--border';
     if (this.args.skin == 'action') return 'au-c-pill--ongoing';

--- a/addon/private/helpers/link-to-models.js
+++ b/addon/private/helpers/link-to-models.js
@@ -15,7 +15,7 @@ import { assert } from '@ember/debug';
  * https://github.com/emberjs/ember.js/blob/v3.26.1/packages/%40ember/-internals/glimmer/lib/components/link-to.ts#L524-L540
  */
 
-export function auLinkToModels([model, models]) {
+export function linkToModels([model, models]) {
   assert(
     'You cannot provide both the `@model` and `@models` arguments to the component.',
     !model || !models
@@ -30,4 +30,4 @@ export function auLinkToModels([model, models]) {
   }
 }
 
-export default helper(auLinkToModels);
+export default helper(linkToModels);

--- a/app/helpers/au-link-to-models.js
+++ b/app/helpers/au-link-to-models.js
@@ -1,1 +1,0 @@
-export { default } from '@appuniversum/ember-appuniversum/helpers/au-link-to-models';

--- a/tests/unit/helpers/au-link-to-models-test.js
+++ b/tests/unit/helpers/au-link-to-models-test.js
@@ -1,13 +1,13 @@
-import { auLinkToModels } from '@appuniversum/ember-appuniversum/helpers/au-link-to-models';
+import { linkToModels } from '@appuniversum/ember-appuniversum/private/helpers/link-to-models';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Helper | au-link-to-models', function (hooks) {
+module('Unit | Helper | Private | link-to-models', function (hooks) {
   setupTest(hooks);
 
   test('it supports passing in a model as the first positional argument', function (assert) {
     let modelId = 1;
-    let result = auLinkToModels([modelId]);
+    let result = linkToModels([modelId]);
 
     assert.ok(Array.isArray(result));
     assert.strictEqual(result[0], 1);
@@ -15,7 +15,7 @@ module('Unit | Helper | au-link-to-models', function (hooks) {
 
   test('it supports passing in a models array as the second positional argument', function (assert) {
     let models = [1, 2, 3];
-    let result = auLinkToModels([undefined, models]);
+    let result = linkToModels([undefined, models]);
 
     assert.ok(Array.isArray(result));
     assert.strictEqual(result[0], 1);
@@ -25,14 +25,14 @@ module('Unit | Helper | au-link-to-models', function (hooks) {
 
   test('it passes through models as provided so the `<LinkTo>` component validation can be reused', function (assert) {
     let models = 1;
-    let result = auLinkToModels([undefined, models]);
+    let result = linkToModels([undefined, models]);
 
     assert.notOk(Array.isArray(result));
     assert.strictEqual(result, 1);
   });
 
   test('it returns an empty array if no model or models are provided', function (assert) {
-    let result = auLinkToModels([]);
+    let result = linkToModels([]);
 
     assert.ok(Array.isArray(result));
     assert.strictEqual(result.length, 0);
@@ -42,7 +42,7 @@ module('Unit | Helper | au-link-to-models', function (hooks) {
     let result;
 
     assert.throws(() => {
-      result = auLinkToModels([1, [1, 2]]);
+      result = linkToModels([1, [1, 2]]);
     });
 
     assert.notOk(result);


### PR DESCRIPTION
By moving it into a private folder and removing the app re-export, it is very clear that this helper shouldn't be used outside of this addon itself.