### PR TITLE
Deprecate the `#ember-appuniversum-wormhole` element

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -53,5 +53,4 @@
   }
 </style>
 
-<div id="ember-appuniversum-wormhole"></div>
 <div id="ember-basic-dropdown-wormhole"></div>

--- a/addon/components/au-modal-container.hbs
+++ b/addon/components/au-modal-container.hbs
@@ -1,0 +1,1 @@
+<div data-au-modal-container ...attributes></div>

--- a/addon/components/au-modal.js
+++ b/addon/components/au-modal.js
@@ -1,9 +1,19 @@
+import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
 export default class AuModal extends Component {
-  get destinationElement() {
-    return document.getElementById('ember-appuniversum-wormhole');
+  constructor() {
+    super(...arguments);
+
+    this.destinationElement =
+      document.querySelector('[data-au-modal-container]') ||
+      document.getElementById('ember-appuniversum-wormhole');
+
+    assert(
+      'au-modal: No target element was found. Please add the `<AuModalContainer />` component where appropriate.',
+      this.destinationElement
+    );
   }
 
   get size() {

--- a/app/components/au-modal-container.js
+++ b/app/components/au-modal-container.js
@@ -1,0 +1,1 @@
+export { default } from '@appuniversum/ember-appuniversum/components/au-modal-container';

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -22,6 +22,7 @@ module.exports = function (defaults) {
     '@appuniversum/ember-appuniversum': {
       dutchDatePickerLocalization:
         process.env.DATE_PICKER_EN_LOCALIZATION === 'true' ? false : true,
+      disableWormholeElement: true,
     },
     fingerprint: {
       // Disable fingerprinting for now until this ember-cli-storybook issue is resolved:

--- a/index.js
+++ b/index.js
@@ -27,11 +27,31 @@ module.exports = {
         '@embroider/macros'
       ].setOwnConfig.dutchDatePickerLocalization = true;
     }
+
+    this.shouldDisableWormholeElementRendering = Boolean(
+      addonOptions.disableWormholeElement
+    );
+
+    this.ui.writeDeprecateLine(
+      `\
+The #ember-appuniversum-wormhole element is deprecated. Please use the \`<AuModalContainer />\` component where appropriate and disable this warning by adding the following flag to your ember-cli-build.js file:
+
+//ember-cli-build.js
+'@appuniversum/ember-appuniversum': {
+  disableWormholeElement: true,
+},
+
+More information: https://github.com/appuniversum/ember-appuniversum/issues/258
+`,
+      this.shouldDisableWormholeElementRendering
+    );
   },
 
   contentFor: function (type) {
     if (type === 'body') {
-      return '<div id="ember-appuniversum-wormhole"></div>';
+      return this.shouldDisableWormholeElementRendering
+        ? ''
+        : '<div id="ember-appuniversum-wormhole"></div>';
     } else {
       return '';
     }

--- a/stories/5-components/Content/AuModal.stories.js
+++ b/stories/5-components/Content/AuModal.stories.js
@@ -53,6 +53,7 @@ export default {
 
 const Template = (args) => ({
   template: hbs`
+    <AuModalContainer />
     <AuModal
       @modalOpen={{this.modalOpen}}
       @closeModal={{this.closeModal}}
@@ -73,6 +74,7 @@ const Template = (args) => ({
 
 const OverflowTemplate = (args) => ({
   template: hbs`
+    <AuModalContainer />
     <AuModal
       @modalOpen={{this.modalOpen}}
       @closeModal={{this.closeModal}}

--- a/tests/integration/components/au-modal-container-test.js
+++ b/tests/integration/components/au-modal-container-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | au-modal-container', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it passes through attributes', async function (assert) {
+    await render(hbs`<AuModalContainer foo="bar" />`);
+
+    assert.dom('[foo]').hasAttribute('foo', 'bar');
+  });
+
+  test("it doesn't render default block contents", async function (assert) {
+    await render(hbs`<AuModalContainer>Foo</AuModalContainer>`);
+
+    assert.dom(this.element).doesNotContainText('Foo');
+  });
+});

--- a/tests/integration/components/au-modal-test.js
+++ b/tests/integration/components/au-modal-test.js
@@ -1,6 +1,12 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render, triggerKeyEvent } from '@ember/test-helpers';
+import {
+  click,
+  render,
+  resetOnerror,
+  setupOnerror,
+  triggerKeyEvent,
+} from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { selectChoose } from 'ember-power-select/test-support';
 
@@ -14,23 +20,48 @@ const MODAL = {
   FOOTER: '[data-test-modal-footer]',
 };
 
-function getWormholeElement() {
-  return document.querySelector('#ember-appuniversum-wormhole');
-}
-
 module('Integration | Component | au-modal', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders when @modalOpen is set to `true`', async function (assert) {
-    await render(hbs`<AuModal />`);
-    assert.dom(MODAL.ELEMENT, getWormholeElement()).doesNotExist();
+    await render(hbs`<AuModalContainer/><AuModal />`);
+    assert.dom(MODAL.ELEMENT).doesNotExist();
 
-    await render(hbs`<AuModal @modalOpen={{true}} />`);
-    assert.dom(MODAL.ELEMENT, getWormholeElement()).exists();
+    await render(hbs`<AuModalContainer /><AuModal @modalOpen={{true}} />`);
+    assert.dom(MODAL.ELEMENT).exists();
+  });
+
+  test("it falls back to the #ember-appuniversum-wormhole element if the AuModalContainer component isn't used", async function (assert) {
+    function getFallbackWormholeElement() {
+      return document.querySelector('#ember-appuniversum-wormhole');
+    }
+
+    await render(hbs`
+      <div id="ember-appuniversum-wormhole"></div>
+      <AuModal @modalOpen={{true}} />
+    `);
+
+    assert.dom(MODAL.ELEMENT, getFallbackWormholeElement()).exists();
+  });
+
+  test('it throws an error if no target element was found', async function (assert) {
+    setupOnerror((error) => {
+      if (error.message.includes('au-modal: No target element was found')) {
+        assert.step('correct error thrown');
+      }
+    });
+
+    await render(hbs`
+      <AuModal @modalOpen={{true}} />
+    `);
+
+    assert.verifySteps(['correct error thrown']);
+    resetOnerror();
   });
 
   test('it yields body and footer components', async function (assert) {
     await render(hbs`
+      <AuModalContainer />
       <AuModal @modalOpen={{true}} as |Modal|>
         <Modal.Body>
           Body
@@ -41,24 +72,26 @@ module('Integration | Component | au-modal', function (hooks) {
       </AuModal>
     `);
 
-    assert.dom(MODAL.BODY, getWormholeElement()).containsText('Body');
-    assert.dom(MODAL.FOOTER, getWormholeElement()).containsText('Footer');
+    assert.dom(MODAL.BODY).containsText('Body');
+    assert.dom(MODAL.FOOTER).containsText('Footer');
   });
 
   test('it has named blocks for the body and footer', async function (assert) {
     await render(hbs`
+      <AuModalContainer />
       <AuModal @modalOpen={{true}}>
         <:body>Body</:body>
         <:footer>Footer</:footer>
       </AuModal>
     `);
 
-    assert.dom(MODAL.BODY, getWormholeElement()).hasText('Body');
-    assert.dom(MODAL.FOOTER, getWormholeElement()).hasText('Footer');
+    assert.dom(MODAL.BODY).hasText('Body');
+    assert.dom(MODAL.FOOTER).hasText('Footer');
   });
 
   test('it stops yielding the contextual components once a named block is used', async function (assert) {
     await render(hbs`
+      <AuModalContainer />
       <AuModal @modalOpen={{true}}>
         <:default as |Modal|>
           <Modal.Body>Not rendered</Modal.Body>
@@ -69,46 +102,36 @@ module('Integration | Component | au-modal', function (hooks) {
       </AuModal>
     `);
 
-    assert
-      .dom(MODAL.BODY, getWormholeElement())
-      .exists({ count: 1 })
-      .hasText('Body');
-
-    assert
-      .dom(MODAL.FOOTER, getWormholeElement())
-      .exists({ count: 1 })
-      .hasText('Footer');
+    assert.dom(MODAL.BODY).exists({ count: 1 }).hasText('Body');
+    assert.dom(MODAL.FOOTER).exists({ count: 1 }).hasText('Footer');
   });
 
-  test("it's title can be set through an argument or a named block", async function (assert) {
+  test('its title can be set through an argument or a named block', async function (assert) {
     await render(hbs`
+      <AuModalContainer />
       <AuModal @title="Title set through @title" @modalOpen={{true}}/>
     `);
 
-    assert
-      .dom(MODAL.TITLE, getWormholeElement())
-      .hasText('Title set through @title');
+    assert.dom(MODAL.TITLE).hasText('Title set through @title');
 
     await render(hbs`
+      <AuModalContainer />
       <AuModal @modalOpen={{true}}>
         <:title>Title set through block</:title>
       </AuModal>
     `);
 
-    assert
-      .dom(MODAL.TITLE, getWormholeElement())
-      .hasText('Title set through block');
+    assert.dom(MODAL.TITLE).hasText('Title set through block');
 
     // the block version is prioritized
     await render(hbs`
+      <AuModalContainer />
       <AuModal @title="Title set through @title" @modalOpen={{true}}>
         <:title>Title set through block</:title>
       </AuModal>
     `);
 
-    assert
-      .dom(MODAL.TITLE, getWormholeElement())
-      .hasText('Title set through block');
+    assert.dom(MODAL.TITLE).hasText('Title set through block');
   });
 
   test('it calls `@closeModal` when the modal should be closed', async function (assert) {
@@ -121,6 +144,7 @@ module('Integration | Component | au-modal', function (hooks) {
     this.isOpen = true;
 
     await render(hbs`
+      <AuModalContainer />
       <AuModal @modalOpen={{this.isOpen}} @closeModal={{this.handleClose}}></AuModal>
     `);
 
@@ -145,6 +169,7 @@ module('Integration | Component | au-modal', function (hooks) {
     this.isOpen = true;
 
     await render(hbs`
+      <AuModalContainer />
       <AuModal @modalOpen={{this.isOpen}} @closeModal={{this.handleClose}}></AuModal>
     `);
 
@@ -176,6 +201,7 @@ module('Integration | Component | au-modal', function (hooks) {
     this.isOpen = true;
 
     await render(hbs`
+      <AuModalContainer />
       <AuModal @modalOpen={{this.isOpen}} @closeModal={{this.handleClose}}></AuModal>
     `);
 
@@ -196,6 +222,7 @@ module('Integration | Component | au-modal', function (hooks) {
     this.onChange = () => {};
 
     await render(hbs`
+      <AuModalContainer />
       <AuModal @modalOpen={{this.isOpen}} @closeModal={{this.handleClose}}>
         <:body>
           <PowerSelect
@@ -223,6 +250,7 @@ module('Integration | Component | au-modal', function (hooks) {
     this.showModal = true;
 
     await render(hbs`
+      <AuModalContainer />
       {{#if this.showModal}}
         <AuModal @modalOpen={{true}} @closeModal={{this.handleClose}}></AuModal>
         <button data-test-close-button type="button" {{on "click" this.handleClose}}>Close modal</button>


### PR DESCRIPTION
This deprecates the element that is added to the index.html file during the build. Users can now use the `AuModalContainer` component instead. (The `app/templates/routes/application.hbs` is a good place to put it).

To hide the deprecation warning a build-time flag can be added to the app's ember-cli-build.js file:

```js
'@appuniversum/ember-appuniversum': {
  disableWormholeElement: true,
},
```

Closes #258 