### PR TITLE
Add a `<AuDateInput>` component

### DIFF
--- a/addon/components/au-date-input.hbs
+++ b/addon/components/au-date-input.hbs
@@ -1,0 +1,14 @@
+<span class="au-c-input-wrapper {{this.width}}">
+  <input
+    class="au-c-input
+      {{this.error}}
+      {{this.warning}}
+      {{this.width}}
+      {{this.disabled}}"
+    disabled={{@disabled}}
+    placeholder="DD-MM-JJJJ"
+    ...attributes
+    {{this.dateInput value=@value prefillYear=@prefillYear onChange=@onChange}}
+  />
+  <AuIcon @icon="calendar" @alignment="left" />
+</span>

--- a/addon/components/au-date-input.js
+++ b/addon/components/au-date-input.js
@@ -1,0 +1,128 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+import { registerDestructor } from '@ember/destroyable';
+import Modifier from 'ember-modifier';
+import Inputmask from 'inputmask';
+import {
+  toIsoDateString,
+  isIsoDateString,
+  isoDateToBelgianFormat,
+} from '@appuniversum/ember-appuniversum/utils/date';
+
+export default class AuDateInputComponent extends Component {
+  dateInput = DateInputModifier;
+
+  // These getters need to be kept in sync with the AuInput component.
+  // Once we refactor that component so it no longer uses `<Input>` we can remove the duplication and wrap AuInput instead.
+  get width() {
+    if (this.args.width == 'block') return 'au-c-input--block';
+    else return '';
+  }
+
+  get error() {
+    if (this.args.error) return 'au-c-input--error';
+    else return '';
+  }
+
+  get warning() {
+    if (this.args.warning) return 'au-c-input--warning';
+    else return '';
+  }
+
+  get disabled() {
+    if (this.args.disabled) return 'is-disabled';
+    else return '';
+  }
+}
+
+class DateInputModifier extends Modifier {
+  input;
+  argValue;
+  argOnChange;
+  currentIsoDate;
+
+  constructor() {
+    super(...arguments);
+    registerDestructor(this, this.removeInputmask);
+  }
+
+  get isInitialized() {
+    return Boolean(this.input);
+  }
+
+  modify(input, positional, { value, onChange, prefillYear = false }) {
+    let valueHasChanged = this.argValue !== value;
+
+    if (valueHasChanged || !this.isInitialized) {
+      this.argValue = value;
+      let isoDate = ensureIsoDate(value);
+      this.currentIsoDate = isoDate;
+      input.value = isoDate ? isoDateToBelgianFormat(isoDate) : '';
+    }
+
+    if (this.argOnChange !== onChange) {
+      this.argOnChange = onChange;
+    }
+
+    if (!this.isInitialized) {
+      this.initialize(input, prefillYear);
+    }
+  }
+
+  initialize(input, prefillYear) {
+    this.input = input;
+
+    let inputmask = new Inputmask({
+      alias: 'datetime',
+      inputFormat: 'dd-mm-yyyy',
+      outputFormat: 'yyyy-mm-dd',
+      placeholder: 'DD-MM-JJJJ',
+      prefillYear,
+      oncomplete: () => {
+        let isoDate = this.input.inputmask.unmaskedvalue();
+
+        if (isoDate !== this.currentIsoDate) {
+          this.currentIsoDate = isoDate;
+          this.onChange(isoDate, new Date(isoDate));
+        }
+      },
+      oncleared: () => {
+        if (this.currentIsoDate !== null) {
+          this.currentIsoDate = null;
+          this.onChange(null, null);
+        }
+      },
+    });
+
+    inputmask.mask(input);
+  }
+
+  onChange(isoDate, date) {
+    this.argOnChange?.(isoDate, date);
+  }
+
+  removeInputmask = () => {
+    this.input.inputmask?.remove();
+  };
+}
+
+function ensureIsoDate(argValue) {
+  if (!argValue) {
+    return;
+  }
+
+  assert(
+    `@value should be a ISO 8601 formatted date string or a Date instance but it is a "${typeof argValue}"`,
+    typeof argValue === 'string' || argValue instanceof Date
+  );
+
+  if (argValue instanceof Date) {
+    return toIsoDateString(argValue);
+  } else {
+    assert(
+      `@value ("${argValue}") should be a valid ISO 8601 formatted date`,
+      isIsoDateString(argValue)
+    );
+    return argValue;
+  }
+}

--- a/addon/components/au-date-picker.js
+++ b/addon/components/au-date-picker.js
@@ -4,8 +4,11 @@ import { action } from '@ember/object';
 import { assert, deprecate, runInDebug } from '@ember/debug';
 import { guidFor } from '@ember/object/internals';
 import { getOwnConfig, macroCondition } from '@embroider/macros';
-import formatISO from 'date-fns/formatISO';
-import { formatDate } from '@appuniversum/ember-appuniversum/utils/date';
+import {
+  formatDate,
+  toIsoDateString,
+  isIsoDateString,
+} from '@appuniversum/ember-appuniversum/utils/date';
 
 const DEFAULT_ADAPTER = {
   parse: function (value = '', createDate) {
@@ -193,7 +196,7 @@ function asIsoDate(target, key /*, descriptor */) {
       }
 
       assert(
-        `@${key} should be a string or a Date instance but it is a "${typeof valueArg}"`,
+        `@${key} should be a string or a Date instance but it is a "${typeof argValue}"`,
         typeof argValue === 'string' || argValue instanceof Date
       );
 
@@ -208,20 +211,6 @@ function asIsoDate(target, key /*, descriptor */) {
       }
     },
   };
-}
-
-function toIsoDateString(date) {
-  return formatISO(date, { representation: 'date' });
-}
-
-function isIsoDateString(isoDate) {
-  let date = new Date(isoDate);
-
-  return isValidDate(date) && isoDate === toIsoDateString(date);
-}
-
-function isValidDate(date) {
-  return !isNaN(date);
 }
 
 function getLocalizedMonths(monthFormat = 'long') {

--- a/addon/utils/date.js
+++ b/addon/utils/date.js
@@ -1,5 +1,3 @@
-import formatISO from 'date-fns/formatISO';
-
 export function formatDate(date) {
   let day = `${date.getDate()}`.padStart(2, '0');
   let month = `${date.getMonth() + 1}`.padStart(2, '0');
@@ -8,7 +6,10 @@ export function formatDate(date) {
 }
 
 export function toIsoDateString(date) {
-  return formatISO(date, { representation: 'date' });
+  let day = `${date.getDate()}`.padStart(2, '0');
+  let month = `${date.getMonth() + 1}`.padStart(2, '0');
+
+  return `${date.getFullYear()}-${month}-${day}`;
 }
 
 export function isIsoDateString(isoDate) {

--- a/addon/utils/date.js
+++ b/addon/utils/date.js
@@ -1,6 +1,28 @@
+import formatISO from 'date-fns/formatISO';
+
 export function formatDate(date) {
   let day = `${date.getDate()}`.padStart(2, '0');
   let month = `${date.getMonth() + 1}`.padStart(2, '0');
 
   return `${day}-${month}-${date.getFullYear()}`;
+}
+
+export function toIsoDateString(date) {
+  return formatISO(date, { representation: 'date' });
+}
+
+export function isIsoDateString(isoDate) {
+  let date = new Date(isoDate);
+
+  return isValidDate(date) && isoDate === toIsoDateString(date);
+}
+
+export function isValidDate(date) {
+  return !isNaN(date);
+}
+
+export function isoDateToBelgianFormat(isoDate) {
+  let [year, month, day] = isoDate.split('-');
+
+  return `${day}-${month}-${year}`;
 }

--- a/app/components/au-date-input.js
+++ b/app/components/au-date-input.js
@@ -1,0 +1,1 @@
+export { default } from '@appuniversum/ember-appuniversum/components/au-date-input';

--- a/app/styles/ember-appuniversum/_c-input.scss
+++ b/app/styles/ember-appuniversum/_c-input.scss
@@ -60,6 +60,7 @@ $au-input-border-radius             : .3rem !default;
     width: 1.6rem;
     margin-left: $au-unit-small;
     margin-right: $au-unit-small;
+    pointer-events: none; // allow users to focus the field by "clicking" the icon
   }
 
   .au-c-icon--right {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11765,7 +11765,8 @@
     "date-fns": {
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "dev": true
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@zestia/ember-auto-focus": "^4.2.0",
-    "date-fns": "^2.28.0",
     "ember-auto-import": "^2.4.1",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "ember-inputmask5": "^4.0.2",
     "ember-modifier": "^3.2.7",
     "ember-test-selectors": "^6.0.0",
+    "inputmask": "^5.0.7",
     "merge-anything": "^5.1.3",
     "tracked-toolbox": "^1.2.3"
   },

--- a/stories/5-components/Forms/AuDateInput.stories.js
+++ b/stories/5-components/Forms/AuDateInput.stories.js
@@ -1,0 +1,48 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'Components/Forms/AuDateInput',
+  argTypes: {
+    value: { control: 'date', description: 'Set the selected date' },
+    error: { control: 'boolean', description: 'Add an error state' },
+    warning: { control: 'boolean', description: 'Add a warning state' },
+    disabled: {
+      control: 'boolean',
+      description: 'Makes the date picker input component disabled',
+    },
+    prefillYear: {
+      control: 'boolean',
+      description:
+        'When enabled it tries to inteligently prefill the year after typing 2 characters. `20` will be autocompleted to `2023`, but the user can continue typing the last 2 numbers if the year is different.',
+    },
+    onChange: {
+      action: 'date-changed',
+      description:
+        'Gets called when the date changes. Returns the date as both an ISO 8601 string and Date instance or null when the input field is cleared.',
+    },
+  },
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <AuDateInput
+      @value={{this.value}}
+      @error={{this.error}}
+      @warning={{this.warning}}
+      @disabled={{this.disabled}}
+      @prefillYear={{this.prefillYear}}
+      @onChange={{this.onChange}}
+    />`,
+  context: args,
+});
+
+export const Component = Template.bind({});
+Component.args = {
+  error: false,
+  warning: false,
+  disabled: false,
+  prefillYear: false,
+};

--- a/tests/integration/components/au-date-input-test.js
+++ b/tests/integration/components/au-date-input-test.js
@@ -1,0 +1,91 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { typeIn, fillIn, render, triggerKeyEvent } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | au-date-input', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it adds attributes to the input element', async function (assert) {
+    await render(hbs`
+      <AuDateInput data-test-date-input />
+    `);
+
+    assert.dom('[data-test-date-input]').hasTagName('input');
+  });
+
+  test('it supports disabling the date input', async function (assert) {
+    await render(hbs`
+      <AuDateInput @disabled={{true}} data-test-date-input />
+    `);
+
+    assert.dom('[data-test-date-input]').hasAttribute('disabled');
+  });
+
+  test('it accepts an iso date string or date object as a value', async function (assert) {
+    this.value = '2023-02-02';
+
+    await render(hbs`
+      <AuDateInput data-test-date-input @value={{this.value}} />
+    `);
+
+    assert.dom('[data-test-date-input]').hasValue('02-02-2023');
+
+    this.set('value', new Date(2024, 5, 3));
+    assert.dom('[data-test-date-input]').hasValue('03-06-2024');
+
+    this.set('value', undefined);
+    assert.dom('[data-test-date-input]').hasNoValue();
+  });
+
+  test('it calls @onChange with the correct date', async function (assert) {
+    assert.expect(2);
+    this.onChange = (isoDate, date) => {
+      assert.strictEqual(
+        isoDate,
+        '2023-02-02',
+        'it returns the date in iso string format'
+      );
+      assert.true(
+        date instanceof Date,
+        'it returns a date object as the second argument'
+      );
+    };
+
+    await render(hbs`
+      <AuDateInput data-test-date-input @onChange={{this.onChange}} />
+    `);
+
+    await fillIn('[data-test-date-input]', '0202202');
+    await typeIn('[data-test-date-input]', '3'); // fillIn alone doesn't do the trick, but typeIn has issues when typing all the characters..
+  });
+
+  test('it calls @onChange with `null` if the input is cleared', async function (assert) {
+    assert.expect(2);
+    this.onChange = (isoDate, date) => {
+      assert.strictEqual(
+        isoDate,
+        null,
+        'it returns null if the input is cleared'
+      );
+      assert.strictEqual(date, null, 'it returns null if the input is cleared');
+    };
+
+    await render(hbs`
+      <AuDateInput data-test-date-input @value="2023-02-02" @onChange={{this.onChange}} />
+    `);
+
+    let input = document.querySelector('[data-test-date-input]');
+
+    await clearInput(input);
+  });
+});
+
+async function clearInput(input) {
+  // Focus seems to be needed to make the backspace work
+  input.focus();
+
+  while (input.value.length > 0) {
+    await triggerKeyEvent(input, 'keydown', 'Backspace');
+  }
+}


### PR DESCRIPTION
This adds a new `<AuDateInput>` component that should be a drop-in replacement for the `<AuDatePicker>` component.


https://user-images.githubusercontent.com/3533236/216779830-60c6520e-d0f4-444d-b4c1-c816524ed4b1.mov



Closes #119 