### PR TITLE
Use the proper name for the checkbox and radio components in the documentation

### DIFF
--- a/stories/5-components/Forms/AuCheckbox.stories.js
+++ b/stories/5-components/Forms/AuCheckbox.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Components/Forms/AuCheckbox',
+  title: 'Components/Forms/AuControlCheckbox',
   argTypes: {
     label: { control: 'text', description: 'Set label text' },
     identifier: {

--- a/stories/5-components/Forms/AuRadio.stories.js
+++ b/stories/5-components/Forms/AuRadio.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Components/Forms/AuRadio',
+  title: 'Components/Forms/AuControlRadio',
   argTypes: {
     label: { control: 'text', description: 'Set label text' },
     name: {


### PR DESCRIPTION
Closes #365 

I didn't rename the files themselves since I plan on renaming the components anyways.