### PR TITLE
Add a `@maskOptions` argument to the AuInput component 

### DIFF
--- a/addon/components/au-input.hbs
+++ b/addon/components/au-input.hbs
@@ -1,15 +1,14 @@
 {{#if @icon}}
   <span class="au-c-input-wrapper {{this.iconAlignment}} {{this.width}}">
-    {{#if @mask}}
-      <Inputmask
-        @value={{@value}}
-        @mask={{@mask}}
-        @placeholder={{@maskPlaceholder}}
-        @update={{this.handleChange}}
+    {{#if this.isMasked}}
+      <input
+        type={{this.type}}
+        value={{@value}}
         class={{this.classes}}
         disabled={{@disabled}}
-        type={{this.type}}
         ...attributes
+        {{on "input" this.handleChange}}
+        {{this.inputmaskModifier inputmaskOptions=this.inputmaskOptions}}
       />
     {{else}}
       <Input
@@ -27,16 +26,15 @@
     {{/if}}
   </span>
 {{else}}
-  {{#if @mask}}
-    <Inputmask
-      @value={{@value}}
-      @mask={{@mask}}
-      @placeholder={{@maskPlaceholder}}
-      @update={{this.handleChange}}
+  {{#if this.isMasked}}
+    <input
+      type={{this.type}}
+      value={{@value}}
       class={{this.classes}}
       disabled={{@disabled}}
-      type={{this.type}}
       ...attributes
+      {{on "input" this.handleChange}}
+      {{this.inputmaskModifier inputmaskOptions=this.inputmaskOptions}}
     />
   {{else}}
     <Input

--- a/addon/components/au-input.hbs
+++ b/addon/components/au-input.hbs
@@ -6,11 +6,7 @@
         @mask={{@mask}}
         @placeholder={{@maskPlaceholder}}
         @update={{this.handleChange}}
-        class="au-c-input au-c-input--mask
-          {{this.error}}
-          {{this.warning}}
-          {{this.width}}
-          {{this.disabled}}"
+        class={{this.classes}}
         disabled={{@disabled}}
         type={{this.type}}
         ...attributes
@@ -19,11 +15,7 @@
       <Input
         @value={{@value}}
         @type={{this.type}}
-        class="au-c-input
-          {{this.error}}
-          {{this.warning}}
-          {{this.width}}
-          {{this.disabled}}"
+        class={{this.classes}}
         disabled={{@disabled}}
         ...attributes
       />
@@ -41,11 +33,7 @@
       @mask={{@mask}}
       @placeholder={{@maskPlaceholder}}
       @update={{this.handleChange}}
-      class="au-c-input au-c-input--mask
-        {{this.error}}
-        {{this.warning}}
-        {{this.width}}
-        {{this.disabled}}"
+      class={{this.classes}}
       disabled={{@disabled}}
       type={{this.type}}
       ...attributes
@@ -54,11 +42,7 @@
     <Input
       @value={{@value}}
       @type={{this.type}}
-      class="au-c-input
-        {{this.error}}
-        {{this.warning}}
-        {{this.width}}
-        {{this.disabled}}"
+      class={{this.classes}}
       disabled={{@disabled}}
       ...attributes
     />

--- a/addon/components/au-input.js
+++ b/addon/components/au-input.js
@@ -1,15 +1,17 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import { modifier } from 'ember-modifier';
+import Inputmask from 'inputmask';
 
 export default class AuInput extends Component {
   constructor() {
     super(...arguments);
 
     assert(
-      '<AuInput>: An `@onChange` handler was provided but that will only be called if a `@mask` is provided as well.',
+      '<AuInput>: An `@onChange` handler was provided but that will only be called if `@mask` or `@maskOptions` is provided as well.',
       !this.args.onChange ||
-        (typeof this.args.onChange === 'function' && this.args.mask)
+        (typeof this.args.onChange === 'function' && this.isMasked)
     );
   }
 
@@ -56,8 +58,54 @@ export default class AuInput extends Component {
       .join(' ');
   }
 
+  get isMasked() {
+    return Boolean(this.args.mask) || Boolean(this.args.maskOptions);
+  }
+
+  get inputmaskModifier() {
+    return this.isMasked ? InputmaskModifier : undefined;
+  }
+
+  get inputmaskOptions() {
+    if (!this.isMasked) {
+      return {};
+    }
+
+    let { mask, maskPlaceholder, maskOptions = {} } = this.args;
+
+    let options = {
+      ...maskOptions,
+    };
+
+    if (mask) {
+      options.mask = mask;
+    }
+
+    if (maskPlaceholder) {
+      options.placeholder = maskPlaceholder;
+    }
+
+    return options;
+  }
+
   @action
-  handleChange(value) {
+  handleChange(event) {
+    let value = event.target.inputmask.unmaskedvalue();
     this.args.onChange?.(value);
   }
 }
+
+const InputmaskModifier = modifier(
+  (input, positional, { inputmaskOptions }) => {
+    let inputmask = new Inputmask({
+      ...inputmaskOptions,
+    });
+
+    inputmask.mask(input);
+
+    return () => {
+      input.inputmask.remove();
+    };
+  },
+  { eager: false }
+);

--- a/addon/components/au-input.js
+++ b/addon/components/au-input.js
@@ -43,6 +43,19 @@ export default class AuInput extends Component {
     return this.args.type || 'text';
   }
 
+  get classes() {
+    return [
+      'au-c-input',
+      this.isMasked ? 'au-c-input--mask' : '',
+      this.error,
+      this.warning,
+      this.disabled,
+      this.width,
+    ]
+      .filter(Boolean)
+      .join(' ');
+  }
+
   @action
   handleChange(value) {
     this.args.onChange?.(value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1449,6 +1449,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-2.0.4.tgz",
       "integrity": "sha512-Zh/fo5VUmVzYHkHVvzWVjJ1RjFUxA2jH0zCp2+DQa80Bf3DUXauiEByxU22UkN4LFT55DBFttC0xCQSJG3WTsg==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "@embroider/macros": "^1.0.0",
         "ember-cli-babel": "^7.26.11",
@@ -15557,17 +15559,6 @@
         }
       }
     },
-    "ember-inputmask5": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ember-inputmask5/-/ember-inputmask5-4.0.2.tgz",
-      "integrity": "sha512-rPDSsT0wXht21oWB0F9mrZODjpLydMOdcU3oj6zdMWedstp/Ds+5bAabgUqSWAxVRayjbfxYC+AAaOwoy4dyIQ==",
-      "requires": {
-        "@ember/render-modifiers": "^2.0.4",
-        "@embroider/addon-shim": "^1.8.3",
-        "ember-modifier": "^3.2.7",
-        "inputmask": "^5.0.7"
-      }
-    },
     "ember-load-initializers": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ember-load-initializers/-/ember-load-initializers-2.1.2.tgz",
@@ -16113,6 +16104,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
       "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "ember-cli-babel": "^7.10.0",
         "ember-cli-version-checker": "^2.1.2",
@@ -16123,6 +16116,8 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -16131,7 +16126,9 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "ember-data-table": "^2.1.0",
     "ember-file-upload": "^7.0.3",
     "ember-focus-trap": "^1.0.1",
-    "ember-inputmask5": "^4.0.2",
     "ember-modifier": "^3.2.7",
     "ember-test-selectors": "^6.0.0",
     "inputmask": "^5.0.7",

--- a/stories/5-components/Forms/AuInput.stories.js
+++ b/stories/5-components/Forms/AuInput.stories.js
@@ -4,7 +4,6 @@ import { icons } from '../../assets/icons';
 export default {
   title: 'Components/Forms/AuInput',
   argTypes: {
-    id: { control: 'text', description: '' },
     error: { control: 'boolean', description: 'Add an error state' },
     warning: { control: 'boolean', description: 'Add an warning state' },
     disabled: {
@@ -30,14 +29,18 @@ export default {
     mask: {
       control: 'text',
       description:
-        'Define the input mask you want to add. See https://github.com/sinankeskin/ember-inputmask for more options.',
+        'Define the input mask you want to add. See https://github.com/RobinHerbots/Inputmask for more options.',
     },
     maskPlaceholder: {
       control: 'text',
       description: 'Define the input mask placeholder',
     },
-    handleChange: {
-      control: 'function',
+    maskOptions: {
+      description:
+        'A more flexible alternative to the `@mask` and `@maskPlaceholder` arguments. This object will be passed into the InputMask instance. See https://github.com/RobinHerbots/Inputmask for more options.',
+    },
+    onChange: {
+      action: 'change',
       description:
         'This action will be called when the value changes and will be passed to the unmasked value and the masked value.',
     },
@@ -54,7 +57,7 @@ export default {
 const Template = (args) => ({
   template: hbs`
     <AuInput
-      id={{this.id}}
+      @value={{this.value}}
       @error={{this.error}}
       @warning={{this.warning}}
       @disabled={{this.disabled}}
@@ -63,7 +66,7 @@ const Template = (args) => ({
       @iconAlignment={{this.iconAlignment}}
       @mask={{this.mask}}
       @maskPlaceholder={{this.maskPlaceholder}}
-      @handleChange={{this.handleChange}}
+      @maskOptions={{this.maskOptions}}
       @type={{this.type}}
     />`,
   context: args,
@@ -71,7 +74,6 @@ const Template = (args) => ({
 
 export const Component = Template.bind({});
 Component.args = {
-  id: '',
   error: false,
   warning: false,
   disabled: false,
@@ -84,13 +86,15 @@ Component.args = {
 
 export const InputMask = Template.bind({});
 InputMask.args = {
-  id: '',
+  value: '',
   error: false,
   warning: false,
   disabled: false,
   width: '',
   icon: '',
   iconAlignment: 'left',
-  mask: '99.99.99-999.99',
-  maskPlaceholder: '__.__.__-___.__',
+  maskOptions: {
+    mask: '99.99.99-999.99',
+    placeholder: '__.__.__-___.__',
+  },
 };


### PR DESCRIPTION
This allows users to pass options directly into the `Inputmask` instance so it's now a lot more flexible.

At its most basic form, `@maskOptions` can be used as a replacement of `@mask` and `@maskPlaceholder`:
```diff
<AuInput
-  @mask="99.99.99-999.99"
-  @maskPlaceholder="_"
+  @maskOptions={{hash
+    mask="99.99.99-999.99"
+    placeholder="_"
+  }}
  @onChange={{this.setRijksregisternummer}}
/>
```

But it allows users to pass any of the [inputmask options](https://github.com/RobinHerbots/Inputmask#options). This opens up the use of aliases, or any of the event callbacks to have more finegrained control.

Closes #207