### PR TITLE
Improve the consistency between the AuControlCheckbox and AuControlRadio components

### DIFF
--- a/addon/components/au-control-radio.hbs
+++ b/addon/components/au-control-radio.hbs
@@ -1,5 +1,22 @@
-<label for="{{@identifier}}" class="au-c-control au-c-control--radio {{this.disabledClass}} {{unless @label 'au-c-control--labelless'}}">
-  <input name="{{@name}}" id="{{@identifier}}" value="{{@value}}" disabled={{@disabled}} type="radio" class="au-c-control__input" {{on "change" this.onChange}} ...attributes>
+<label
+  for="{{@identifier}}"
+  class="au-c-control au-c-control--radio {{this.disabledClass}} {{unless @label 'au-c-control--labelless'}}"
+>
+  <input
+    name="{{@name}}"
+    id="{{@identifier}}"
+    value="{{@value}}"
+    disabled={{@disabled}}
+    type="radio"
+    checked={{@checked}}
+    class="au-c-control__input"
+    {{on "change" this.onChange}}
+    ...attributes
+  />
   <span class="au-c-control__indicator"></span>
-  {{@label}}
+  {{#if (has-block)}}
+    {{yield}}
+  {{else}}
+    {{@label}}
+  {{/if}}
 </label>

--- a/stories/5-components/Forms/AuFieldset.stories.js
+++ b/stories/5-components/Forms/AuFieldset.stories.js
@@ -61,7 +61,7 @@ const Template = (args) => ({
           @name="radios"
           @value="radioOne"
           @identifier="radioOne"
-          checked={{false}}
+          @checked={{false}}
           @disabled= {{false}}
         />
         <AuControlRadio
@@ -69,7 +69,7 @@ const Template = (args) => ({
           @name="radios"
           @value="radioTwo"
           @identifier="radioTwo"
-          checked={{false}}
+          @checked={{false}}
           @disabled= {{false}}
         />
         <AuControlRadio
@@ -77,7 +77,7 @@ const Template = (args) => ({
           @name="radios"
           @value="radioThree"
           @identifier="radioThree"
-          checked={{false}}
+          @checked={{false}}
           @disabled= {{false}}
         />
       </f.content>

--- a/stories/5-components/Forms/AuRadio.stories.js
+++ b/stories/5-components/Forms/AuRadio.stories.js
@@ -40,7 +40,7 @@ const Template = (args) => ({
       @name={{this.name}}
       @value={{this.value}}
       @identifier={{this.identifier}}
-      checked={{this.checked}}
+      @checked={{this.checked}}
       @disabled= {{this.disabled}}
     />`,
   context: args,

--- a/stories/6-patterns/forms.stories.js
+++ b/stories/6-patterns/forms.stories.js
@@ -30,7 +30,7 @@ const Template = (args) => ({
             @name="radios"
             @value="radioOne"
             @identifier="radioOne"
-            checked={{false}}
+            @checked={{false}}
             @disabled= {{false}}
           />
           <AuControlRadio
@@ -38,7 +38,7 @@ const Template = (args) => ({
             @name="radios"
             @value="radioTwo"
             @identifier="radioTwo"
-            checked={{false}}
+            @checked={{false}}
             @disabled= {{false}}
           />
           <AuControlRadio
@@ -46,7 +46,7 @@ const Template = (args) => ({
             @name="radios"
             @value="radioThree"
             @identifier="radioThree"
-            checked={{false}}
+            @checked={{false}}
             @disabled= {{false}}
           />
         </f.content>
@@ -129,7 +129,7 @@ const TemplateInline = (args) => ({
             @name="radios"
             @value="radioOne"
             @identifier="radioOne"
-            checked={{false}}
+            @checked={{false}}
             @disabled= {{false}}
           />
           <AuControlRadio
@@ -137,7 +137,7 @@ const TemplateInline = (args) => ({
             @name="radios"
             @value="radioTwo"
             @identifier="radioTwo"
-            checked={{false}}
+            @checked={{false}}
             @disabled= {{false}}
           />
           <AuControlRadio
@@ -145,7 +145,7 @@ const TemplateInline = (args) => ({
             @name="radios"
             @value="radioThree"
             @identifier="radioThree"
-            checked={{false}}
+            @checked={{false}}
             @disabled= {{false}}
           />
         </f.content>
@@ -233,7 +233,7 @@ const TemplatePre = (args) => ({
             @name="radios"
             @value="radioOne"
             @identifier="radioOne"
-            checked={{false}}
+            @checked={{false}}
             @disabled= {{false}}
           />
           <AuControlRadio
@@ -241,7 +241,7 @@ const TemplatePre = (args) => ({
             @name="radios"
             @value="radioTwo"
             @identifier="radioTwo"
-            checked={{false}}
+            @checked={{false}}
             @disabled= {{false}}
           />
           <AuControlRadio
@@ -249,7 +249,7 @@ const TemplatePre = (args) => ({
             @name="radios"
             @value="radioThree"
             @identifier="radioThree"
-            checked={{false}}
+            @checked={{false}}
             @disabled= {{false}}
           />
         </f.content>


### PR DESCRIPTION
A rework of the `AuControlRadio` component:
- [x] Equalisation of radio with checkbox component (regarding `@checked` & `yield`/`@label` conditional).
~~- [ ] Creation of new `AuCheckbox` & `AuRadio` component with the addition of a deprecation warning for the 'legacy' version of those components (see comment https://github.com/appuniversum/ember-appuniversum/issues/365#issuecomment-1418722020 by @Windvis).~~ Will be done in a future PR.

If needed, additional work items can be added to this PR.