### PR TITLE
Fix the disableWormholeElement exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,14 +22,14 @@ module.exports = {
       app.options.sassOptions.includePaths || [];
 
     let addonOptions = app.options[this.name];
-    if (addonOptions && addonOptions.dutchDatePickerLocalization) {
+    if (addonOptions?.dutchDatePickerLocalization) {
       this.options[
         '@embroider/macros'
       ].setOwnConfig.dutchDatePickerLocalization = true;
     }
 
     this.shouldDisableWormholeElementRendering = Boolean(
-      addonOptions.disableWormholeElement
+      addonOptions?.disableWormholeElement
     );
 
     this.ui.writeDeprecateLine(


### PR DESCRIPTION
This fixes the problem where an exception is thrown if no config is provided to the addon.