### PR TITLE
Disable the `AuButton` component when it is in the loading state

### DIFF
--- a/addon/components/au-button.hbs
+++ b/addon/components/au-button.hbs
@@ -8,7 +8,7 @@
     {{this.disabledClass}}
     {{this.iconOnlyClass}}
     {{if @wrap 'au-c-button--wrap'}}"
-  disabled={{@disabled}}
+  disabled={{this.isDisabled}}
   type="button"
   ...attributes
 >

--- a/addon/components/au-button.js
+++ b/addon/components/au-button.js
@@ -9,6 +9,10 @@ export default class AuButton extends Component {
     else return 'primary';
   }
 
+  get isDisabled() {
+    return this.args.disabled || this.args.loading;
+  }
+
   get sizeClass() {
     if (this.args.size == 'large' && !this.skin.startsWith('link'))
       return 'au-c-button--large';
@@ -30,7 +34,7 @@ export default class AuButton extends Component {
   }
 
   get disabledClass() {
-    if (this.args.disabled) return 'is-disabled';
+    if (this.isDisabled) return 'is-disabled';
     else return '';
   }
 

--- a/tests/integration/components/au-button-test.js
+++ b/tests/integration/components/au-button-test.js
@@ -7,14 +7,6 @@ module('Integration | Component | au-button', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
-    await render(hbs`<AuButton />`);
-
-    assert.dom(this.element).hasText('');
-
-    // Template block usage:
     await render(hbs`
       <AuButton>
         template block text
@@ -22,5 +14,35 @@ module('Integration | Component | au-button', function (hooks) {
     `);
 
     assert.dom(this.element).hasText('template block text');
+  });
+
+  test('it disables the button when `@disabled` is true', async function (assert) {
+    this.isDisabled = false;
+
+    await render(hbs`
+      <AuButton @loading={{this.isDisabled}} data-test-button>
+        Foo
+      </AuButton>
+    `);
+
+    assert.dom('[data-test-button]').isNotDisabled();
+
+    this.set('isDisabled', true);
+    assert.dom('[data-test-button]').isDisabled();
+  });
+
+  test('it disables the button when `@loading` is true', async function (assert) {
+    this.isLoading = false;
+
+    await render(hbs`
+      <AuButton @loading={{this.isLoading}} @disabled={{false}} data-test-button>
+        Foo
+      </AuButton>
+    `);
+
+    assert.dom('[data-test-button]').isNotDisabled();
+
+    this.set('isLoading', true);
+    assert.dom('[data-test-button]').isDisabled();
   });
 });


### PR DESCRIPTION
Users shouldn't be able to click buttons that are in the loading state since an action is already running.