### PR TITLE
fix(toggle-switch): make width calculations more consistent

### DIFF
--- a/app/styles/ember-appuniversum/_c-toggle-switch.scss
+++ b/app/styles/ember-appuniversum/_c-toggle-switch.scss
@@ -29,7 +29,7 @@ $au-toggle-switch-background-color-on-disabled   : var(--au-gray-400) !default;
   position: relative;
   cursor: pointer;
   height: $au-toggle-switch-height - .4rem;
-  width: $au-toggle-switch-width * 1.5;
+  width: $au-toggle-switch-width * 2;
   background-color: $au-toggle-switch-background-color;
   border-radius: $au-toggle-switch-border-radius;
   transition: transform var(--au-transition), color var(--au-transition);
@@ -80,7 +80,7 @@ $au-toggle-switch-background-color-on-disabled   : var(--au-gray-400) !default;
 }
 
 .au-c-toggle-switch__input:checked + .au-c-toggle-switch__toggle:before {
-  transform: translateX($au-toggle-switch-width*.5 + .2rem);
+  transform: translateX($au-toggle-switch-width*.7);
 }
 
 


### PR DESCRIPTION
Issue that triggered this:
when the toggle component is a child of a flexbox where there's another element taking up all the leftover width, it doesn't reserve enough space for the toggle to look proper, which did not improve with increasing the width variable.
untoggled(too small):
![image](https://user-images.githubusercontent.com/16419862/219373229-fb6bc77b-4b3e-4f28-81a8-48c4c54c3a5f.png)
toggled (too far to the right):
![image](https://user-images.githubusercontent.com/16419862/219373308-9f875384-8a4d-4dfb-871a-464d268f5645.png)



I don't really know if this is the right solution, but it makes sense to me. It also eliminates the absolute offset in the translation, which caused it to render weird with large width settings:

before the change, with width set to 5rem:
![image](https://user-images.githubusercontent.com/16419862/219372718-5bc281e4-d6ea-41f2-88cf-95079c4d09f4.png)

after the change, with width set to 5rem:
![image](https://user-images.githubusercontent.com/16419862/219372972-e4086b2a-f163-4ac1-aec6-8dd6cfc207d5.png)
