### PR TITLE
build(dev): set isDevelopingAddon when appropriate

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@
 
 module.exports = {
   name: require('./package').name,
+  isDevelopingAddon() {
+    return process.env.EMBER_ENV === 'development';
+  },
   options: {
     babel: {
       // This is needed for dynamic imports to work: https://github.com/ef4/ember-auto-import#installing-ember-auto-import-in-an-addon


### PR DESCRIPTION
Kind of incredible this isn't the default in Ember, but this sets the isDevelopingAddon to true when running the host app in dev mode, which means that the host app will rebuild when you change something in the npm-linked local copy of ember-appuniversum