### PR TITLE
Only call `.focus` if the element exist

### DIFF
--- a/addon/components/au-main-header.js
+++ b/addon/components/au-main-header.js
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 export default class AuMainHeader extends Component {
   @action
   headerLinkFocus() {
-    // Focus content window
-    document.querySelectorAll('#main')[0].focus();
+    document.querySelector('#main')?.focus();
   }
 }


### PR DESCRIPTION
This fixes an issue where the AuMainHeader component would trigger a type error exception if the `#main` element didn't exist.

Closes #376 