### PR TITLE
Fix a `<AuToggleSwitch>` shrinking issue

### DIFF
--- a/app/styles/ember-appuniversum/_c-toggle-switch.scss
+++ b/app/styles/ember-appuniversum/_c-toggle-switch.scss
@@ -33,6 +33,7 @@ $au-toggle-switch-background-color-on-disabled: var(--au-gray-400) !default;
   background-color: $au-toggle-switch-background-color;
   border-radius: $au-toggle-switch-border-radius;
   transition: transform var(--au-transition), color var(--au-transition);
+  flex-shrink: 0;
 
   &:before {
     content: "";


### PR DESCRIPTION
This change prevents the visual switch from shrinking below its minimum width.

Before:
![image](https://user-images.githubusercontent.com/3533236/220161966-e4dd2a7f-cde8-4775-9e15-98f0f0da5cc4.png)

After:
![image](https://user-images.githubusercontent.com/3533236/220162041-97b211ac-5787-42b0-bad5-ef4d0436cb0d.png)


Supersedes #377 