### PR TITLE
Addition of new radio, checkbox and group components

### DIFF
--- a/addon/components/au-radio-group.hbs
+++ b/addon/components/au-radio-group.hbs
@@ -1,0 +1,19 @@
+<div
+  class="au-c-control-group {{this.alignmentClass}}"
+  role="group"
+  ...attributes
+  data-test-radio-group
+>
+  {{yield
+    (hash
+      Radio=(component
+        "au-radio"
+        name=(or @name this.uniqueName)
+        groupValue=@value
+        disabled=@disabled
+        onChangeGroup=@onChange
+        inGroup=true
+      )
+    )
+  }}
+</div>

--- a/addon/components/au-radio-group.js
+++ b/addon/components/au-radio-group.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+import { guidFor } from '@ember/object/internals';
+
+export default class AuRadioGroupComponent extends Component {
+  uniqueName = guidFor(this);
+
+  get alignmentClass() {
+    if (this.args.alignment == 'inline') return 'au-c-control-group--inline';
+    else return '';
+  }
+}

--- a/addon/components/au-radio.hbs
+++ b/addon/components/au-radio.hbs
@@ -1,0 +1,18 @@
+<label
+  class="au-c-control au-c-control--radio
+    {{if (and (not @inGroup) (not (has-block))) 'au-c-control--labelless'}}
+    {{if @disabled 'is-disabled'}}"
+>
+  <input
+    type="radio"
+    name={{@name}}
+    value={{this.value}}
+    checked={{this.checked}}
+    disabled={{@disabled}}
+    class="au-c-control__input"
+    {{on "change" this.onChange}}
+    ...attributes
+  />
+  <span class="au-c-control__indicator"></span>
+  {{yield}}
+</label>

--- a/addon/components/au-radio.js
+++ b/addon/components/au-radio.js
@@ -1,0 +1,29 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class AuRadioComponent extends Component {
+  get checked() {
+    const { inGroup, checked, groupValue, value } = this.args;
+    return inGroup ? value === groupValue : checked;
+  }
+
+  get value() {
+    const { value } = this.args;
+    return value === undefined ? undefined : String(value);
+  }
+
+  @action
+  onChange(event) {
+    if (this.args.disabled === true) {
+      return;
+    }
+
+    const { inGroup, onChange, onChangeGroup, value } = this.args;
+
+    if (inGroup && typeof onChangeGroup === 'function') {
+      onChangeGroup(value, event);
+    } else if (typeof onChange === 'function') {
+      onChange(event.target.value, event);
+    }
+  }
+}

--- a/app/components/au-radio-group.js
+++ b/app/components/au-radio-group.js
@@ -1,0 +1,1 @@
+export { default } from '@appuniversum/ember-appuniversum/components/au-radio-group';

--- a/app/components/au-radio.js
+++ b/app/components/au-radio.js
@@ -1,0 +1,1 @@
+export { default } from '@appuniversum/ember-appuniversum/components/au-radio';

--- a/app/styles/ember-appuniversum/_a-components.scss
+++ b/app/styles/ember-appuniversum/_a-components.scss
@@ -16,6 +16,7 @@
 @import "c-content";
 @import "c-content-header";
 @import "c-control";
+@import "c-control-group";
 @import "c-data-table";
 @import "c-dropdown";
 @import "c-fieldset";

--- a/app/styles/ember-appuniversum/_c-control-group.scss
+++ b/app/styles/ember-appuniversum/_c-control-group.scss
@@ -1,0 +1,19 @@
+/* ==================================
+   #Control group
+   ================================== */
+
+/* Component
+   ========================================================================== */
+
+.au-c-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: $au-unit-small;
+
+  &--inline {
+    flex-direction: row;
+    gap: $au-unit;
+    // width: 100%;
+    align-items: center;
+  }
+}

--- a/stories/5-components/Forms/AuRadio.stories.js
+++ b/stories/5-components/Forms/AuRadio.stories.js
@@ -1,18 +1,12 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Components/Forms/AuControlRadio',
+  title: 'Components/Forms/AuRadio',
   argTypes: {
-    label: { control: 'text', description: 'Set label text' },
     name: {
       control: 'text',
       description:
         'Groups radio buttons, to make sure their checked statuses are related',
-    },
-    identifier: {
-      control: 'text',
-      description:
-        'Makes sure the label is linked to the checkbox and clicking it will only activate the checkbox you clicked.',
     },
     value: {
       control: 'text',
@@ -21,11 +15,11 @@ export default {
     },
     checked: {
       control: 'boolean',
-      description: 'Adds a checked state to the radiobutton',
+      description: 'Adds a checked state to the radio button',
     },
     disabled: {
       control: 'boolean',
-      description: 'Adds a disabled state to the radiobutton',
+      description: 'Adds a disabled state to the radio button',
     },
   },
   parameters: {
@@ -35,23 +29,21 @@ export default {
 
 const Template = (args) => ({
   template: hbs`
-    <AuControlRadio
-      @label={{this.label}}
+    <AuRadio
       @name={{this.name}}
       @value={{this.value}}
-      @identifier={{this.identifier}}
       @checked={{this.checked}}
       @disabled= {{this.disabled}}
-    />`,
+    >
+      Ja
+    </AuRadio>`,
   context: args,
 });
 
 export const Component = Template.bind({});
 Component.args = {
-  label: 'Ja',
   name: 'ja-nee',
   value: 'ja',
-  identifier: 'ja',
   checked: false,
   disabled: false,
 };

--- a/stories/5-components/Forms/AuRadioGroup.stories.js
+++ b/stories/5-components/Forms/AuRadioGroup.stories.js
@@ -1,0 +1,59 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'Components/Forms/AuRadioGroup',
+  argTypes: {
+    alignment: {
+      control: 'select',
+      options: ['default', 'inline'],
+      description: 'Choose the layout of the group.',
+    },
+    name: {
+      control: 'text',
+      description:
+        'Groups radio buttons, to make sure their checked statuses are related',
+    },
+    value: {
+      control: 'text',
+      description:
+        'Used to identify which radio button in the group is selected.',
+    },
+    onChange: {
+      control: 'string',
+      description:
+      'Expects a function that gets called when the radio button state changes. The function receives the radio button value & event context as parameters.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Adds a disabled state to all the radio buttons.',
+    },
+  },
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <AuRadioGroup
+      @alignment={{this.alignment}}
+      @name={{this.name}}
+      @value={{this.value}}
+      @disabled= {{this.disabled}}
+      @onChange={{this.onChange}}
+    as |Group|>
+      <Group.Radio @value="radioOne">Radio 1</Group.Radio>
+      <Group.Radio @value="radioTwo">Radio 2</Group.Radio>
+      <Group.Radio @value="radioThree">Radio 3</Group.Radio>
+    </AuRadioGroup>`,
+  context: args,
+});
+
+export const Component = Template.bind({});
+Component.args = {
+  alignment: 'default',
+  name: 'radios',
+  value: 'radioTwo',
+  disabled: false,
+  onChange: '',
+};

--- a/tests/integration/components/au-control-checkbox-test.js
+++ b/tests/integration/components/au-control-checkbox-test.js
@@ -40,16 +40,12 @@ module('Integration | Component | au-control-checkbox', function (hooks) {
   });
 
   test('it can be given a unique identifier', async function (assert) {
-    this.disabled = true;
-
     await render(hbs`<AuControlCheckbox @identifier="123" />`);
     assert.dom('label').hasAttribute('for', '123');
     assert.dom('input').hasAttribute('id', '123');
   });
 
   test('it can be given a name', async function (assert) {
-    this.disabled = true;
-
     await render(hbs`<AuControlCheckbox @name="foo" />`);
     assert.dom('input').hasAttribute('name', 'foo');
   });

--- a/tests/integration/components/au-radio-group-test.js
+++ b/tests/integration/components/au-radio-group-test.js
@@ -1,0 +1,87 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | au-radio-group', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it can be given a name', async function (assert) {
+    await render(hbs`
+      <AuRadioGroup @name="foo" as |Group|>
+        <Group.Radio data-test-foo>Foo</Group.Radio>
+      </AuRadioGroup>
+    `);
+    assert.dom('[data-test-foo]').hasAttribute('name', 'foo');
+  });
+
+  test('if it is given no name, it will automatically generate a unique id', async function (assert) {
+    await render(hbs`
+      <AuRadioGroup as |Group|>
+        <Group.Radio data-test-foo>Foo</Group.Radio>
+      </AuRadioGroup>
+    `);
+    assert.dom('[data-test-foo]').hasAttribute('name', /^ember\d+/); // E.g. 'ember308'
+  });
+
+  test('it can be given a value', async function (assert) {
+    this.groupValue = 'bar';
+    await render(hbs`
+      <AuRadioGroup @value={{this.groupValue}} as |Group|>
+        <Group.Radio @value="foo" data-test-foo>Foo</Group.Radio>
+        <Group.Radio @value="bar" data-test-bar>Bar</Group.Radio>
+      </AuRadioGroup>
+    `);
+
+    assert.dom('[data-test-bar]').isChecked();
+
+    this.set('groupValue', 'foo');
+    assert.dom('[data-test-foo]').isChecked();
+  });
+
+  test('it can be disabled', async function (assert) {
+    this.disabled = true;
+    await render(hbs`
+      <AuRadioGroup @disabled={{this.disabled}} as |Group|>
+        <Group.Radio data-test-foo>Foo</Group.Radio>
+      </AuRadioGroup>
+    `);
+
+    assert.dom('[data-test-foo]').isDisabled();
+
+    this.set('disabled', false);
+    assert.dom('[data-test-foo]').isNotDisabled();
+  });
+
+  test('it calls the provided @onChange action when its state changes by user input', async function (assert) {
+    assert.expect(4);
+
+    this.value = null;
+    this.handleChange = (value, event) => {
+      this.set('value', value);
+      assert.true(event instanceof Event);
+    };
+
+    await render(hbs`
+      <AuRadioGroup @onChange={{this.handleChange}} as |Group|>
+        <Group.Radio @value="foo" data-test-foo>Foo</Group.Radio>
+        <Group.Radio @value="bar" data-test-bar>Bar</Group.Radio>
+      </AuRadioGroup>
+    `);
+
+    await click('[data-test-bar]');
+    assert.strictEqual(this.value, 'bar')
+
+    await click('[data-test-foo]');
+    assert.strictEqual(this.value, 'foo')
+  });
+
+  test('it adds any extra attributes to the group element', async function (assert) {
+    await render(hbs`
+      <AuRadioGroup foo="bar" as |Group|>
+        <Group.Radio>Foo</Group.Radio>
+      </AuRadioGroup>
+    `);
+    assert.dom('[data-test-radio-group]').hasAttribute('foo', 'bar');
+  });
+});

--- a/tests/integration/components/au-radio-test.js
+++ b/tests/integration/components/au-radio-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | au-radio', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('its checked state can be controlled by the parent scope', async function (assert) {
+    await render(hbs`<AuRadio @checked={{this.checked}} />`);
+    assert.dom('input').isNotChecked();
+
+    this.set('checked', true);
+    assert.dom('input').isChecked();
+  });
+
+  test('it can show block content', async function (assert) {
+    await render(hbs`<AuRadio>foo</AuRadio>`);
+    assert.dom().hasText('foo');
+  });
+
+  test('it can be disabled', async function (assert) {
+    this.disabled = true;
+
+    await render(hbs`<AuRadio @disabled={{this.disabled}} />`);
+    assert.dom('label').hasClass('is-disabled');
+    assert.dom('input').isDisabled();
+
+    this.set('disabled', false);
+    assert.dom('label').hasNoClass('is-disabled');
+    assert.dom('input').isNotDisabled();
+  });
+
+  test('it can be given a name', async function (assert) {
+    await render(hbs`<AuRadio @name="foo" />`);
+    assert.dom('input').hasAttribute('name', 'foo');
+  });
+
+  test('it calls the provided @onChange action when its state changes by user input', async function (assert) {
+    assert.expect(2);
+
+    this.value = null;
+    this.handleChange = (value, event) => {
+      this.set('value', value);
+      assert.true(event instanceof Event);
+    };
+
+    await render(hbs`<AuRadio @value="foo" @onChange={{this.handleChange}} />`);
+    await click('label');
+
+    assert.strictEqual(this.value, 'foo')
+  });
+
+  test('it adds any extra attributes to the input element', async function (assert) {
+    await render(hbs`<AuRadio foo="bar" />`);
+    assert.dom('input').hasAttribute('foo', 'bar');
+  });
+});


### PR DESCRIPTION
- The addition of new radio & checkbox components alongside the legacy versions of those, named `AuControlRadio` & `AuControlCheckbox`. This adjustment should close https://github.com/appuniversum/ember-appuniversum/issues/367.
- The addition of new radio-group & checkbox-group components. This adjustment should close https://github.com/appuniversum/ember-appuniversum/issues/356.