### PR TITLE
Refactor the control group components

### DIFF
--- a/addon/components/au-checkbox-group.hbs
+++ b/addon/components/au-checkbox-group.hbs
@@ -7,8 +7,7 @@
   {{yield
     (hash
       Checkbox=(component
-        "au-checkbox"
-        inGroup=true
+        this.GroupCheckbox
         groupValue=@value
         disabled=@disabled
         onChangeGroup=@onChange

--- a/addon/components/au-checkbox-group.js
+++ b/addon/components/au-checkbox-group.js
@@ -1,6 +1,9 @@
 import Component from '@glimmer/component';
+import GroupCheckbox from './au-checkbox-group/checkbox';
 
 export default class AuCheckboxGroupComponent extends Component {
+  GroupCheckbox = GroupCheckbox;
+
   get alignmentClass() {
     if (this.args.alignment == 'inline') return 'au-c-control-group--inline';
     else return '';

--- a/addon/components/au-checkbox-group/checkbox.hbs
+++ b/addon/components/au-checkbox-group/checkbox.hbs
@@ -1,0 +1,7 @@
+<AuCheckbox
+  @checked={{this.isCheckedInGroup}}
+  @disabled={{@disabled}}
+  @name={{@name}}
+  @onChange={{this.onChange}}
+  ...attributes
+>{{yield}}</AuCheckbox>

--- a/addon/components/au-checkbox-group/checkbox.js
+++ b/addon/components/au-checkbox-group/checkbox.js
@@ -1,0 +1,30 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Checkbox extends Component {
+  get groupValue() {
+    return this.args.groupValue || [];
+  }
+
+  get isCheckedInGroup() {
+    return this.groupValue.includes(this.args.name);
+  }
+
+  @action
+  onChange(checked, event) {
+    const { onChangeGroup } = this.args;
+
+    const { groupValue } = this;
+    const { name } = this.args;
+
+    let updatedGroupValue;
+
+    if (checked) {
+      updatedGroupValue = [...groupValue, name];
+    } else {
+      updatedGroupValue = groupValue.filter((n) => n !== name);
+    }
+
+    onChangeGroup?.(updatedGroupValue, event);
+  }
+}

--- a/addon/components/au-checkbox.hbs
+++ b/addon/components/au-checkbox.hbs
@@ -1,12 +1,12 @@
 <label
   class="au-c-control au-c-control--checkbox
-    {{if (and (not @inGroup) (not (has-block))) 'au-c-control--labelless'}}
+    {{if (not (has-block)) 'au-c-control--labelless'}}
     {{if @disabled 'is-disabled'}}"
 >
   <input
     type="checkbox"
     name={{@name}}
-    checked={{this.checked}}
+    checked={{@checked}}
     indeterminate={{@indeterminate}}
     disabled={{@disabled}}
     class="au-c-control__input"

--- a/addon/components/au-checkbox.js
+++ b/addon/components/au-checkbox.js
@@ -2,20 +2,6 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class AuCheckboxComponent extends Component {
-  get groupValue() {
-    return this.args.groupValue || [];
-  }
-
-  get isCheckedInGroup() {
-    const { name } = this.args;
-    return this.groupValue.includes(name);
-  }
-
-  get checked() {
-    const { inGroup, checked } = this.args;
-    return inGroup ? this.isCheckedInGroup : checked;
-  }
-
   @action
   onChange(event) {
     if (this.args.isDisabled === true) {
@@ -23,22 +9,8 @@ export default class AuCheckboxComponent extends Component {
     }
 
     const { checked } = event.target;
-    const { inGroup, onChange, onChangeGroup } = this.args;
-
-    if (inGroup && typeof onChangeGroup === 'function') {
-      const { groupValue } = this;
-      const { name } = this.args;
-
-      let updatedGroupValue;
-
-      if (checked) {
-        updatedGroupValue = [...groupValue, name];
-      } else {
-        updatedGroupValue = groupValue.filter((n) => n !== name);
-      }
-
-      onChangeGroup(updatedGroupValue, event);
-    } else if (typeof onChange === 'function') {
+    const { onChange } = this.args;
+    if (typeof onChange === 'function') {
       onChange(checked, event);
     }
   }

--- a/stories/5-components/Forms/AuCheckboxGroup.stories.js
+++ b/stories/5-components/Forms/AuCheckboxGroup.stories.js
@@ -18,7 +18,7 @@ export default {
       description: 'Adds a disabled state to all the checkboxes.',
     },
     onChange: {
-      control: 'function',
+      action: 'change',
       description:
         'Expects a function that gets called when the state of the checkboxes change. The function receives the checked state of the checkboxs & event context as parameters.',
     },
@@ -48,5 +48,4 @@ Component.args = {
   alignment: 'default',
   value: ['checkboxTwo', 'checkboxThree'],
   disabled: false,
-  onChange: '',
 };


### PR DESCRIPTION
This allows us to split off the group logic from the core checkbox logic, which makes the component easier to maintain.