### PR TITLE
Addition of various functionality for the toggle-switch component

### DIFF
--- a/addon/components/au-toggle-switch.hbs
+++ b/addon/components/au-toggle-switch.hbs
@@ -21,8 +21,6 @@
   {{#if (has-block)}}
     {{yield}}
   {{else if @label}}
-    <span class="au-c-toggle-switch__label">
-      {{@label}}
-    </span>
+    {{@label}}
   {{/if}}
 </label>

--- a/addon/components/au-toggle-switch.hbs
+++ b/addon/components/au-toggle-switch.hbs
@@ -1,6 +1,9 @@
 <label
   for="{{@identifier}}"
-  class="au-c-toggle-switch {{this.disabled}}"
+  class="au-c-toggle-switch
+    {{this.alignmentClass}}
+    {{if (and (not (has-block)) (not @label)) 'au-c-toggle-switch--labelless'}}
+    {{if @disabled 'is-disabled'}}"
   data-test-toggle-switch-label
 >
   <Input
@@ -15,5 +18,11 @@
     ...attributes
   />
   <span class="au-c-toggle-switch__toggle"></span>
-  <span class="au-c-toggle-switch__label">{{@label}}</span>
+  {{#if (has-block)}}
+    {{yield}}
+  {{else if @label}}
+    <span class="au-c-toggle-switch__label">
+      {{@label}}
+    </span>
+  {{/if}}
 </label>

--- a/addon/components/au-toggle-switch.js
+++ b/addon/components/au-toggle-switch.js
@@ -3,7 +3,8 @@ import { action } from '@ember/object';
 
 export default class AuToggleSwitch extends Component {
   get alignmentClass() {
-    if (this.args.alignment === 'right') return 'au-c-toggle-switch--alignment-right';
+    if (this.args.alignment === 'right')
+      return 'au-c-toggle-switch--alignment-right';
     else return '';
   }
 

--- a/addon/components/au-toggle-switch.js
+++ b/addon/components/au-toggle-switch.js
@@ -1,7 +1,26 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { isPresent } from '@ember/utils';
+import { deprecate } from '@ember/debug';
 
 export default class AuToggleSwitch extends Component {
+  constructor() {
+    super(...arguments);
+
+    deprecate(
+      '[AuToggleSwitch] The @label argument for this component is deprecated in favour of using block content.',
+      !isPresent(this.args.label),
+      {
+        id: '@appuniversum/ember-appuniversum.au-toggle-switch.label',
+        until: '3.0.0',
+        for: '@appuniversum/ember-appuniversum',
+        since: {
+          enabled: '2.6.0',
+        },
+      }
+    );
+  }
+
   get alignmentClass() {
     if (this.args.alignment === 'right')
       return 'au-c-toggle-switch--alignment-right';

--- a/addon/components/au-toggle-switch.js
+++ b/addon/components/au-toggle-switch.js
@@ -2,8 +2,8 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class AuToggleSwitch extends Component {
-  get disabled() {
-    if (this.args.disabled) return 'is-disabled';
+  get alignmentClass() {
+    if (this.args.alignment === 'right') return 'au-c-toggle-switch--alignment-right';
     else return '';
   }
 

--- a/app/styles/ember-appuniversum/_c-toggle-switch.scss
+++ b/app/styles/ember-appuniversum/_c-toggle-switch.scss
@@ -21,7 +21,8 @@ $au-toggle-switch-background-color-on-disabled: var(--au-gray-400) !default;
 
 .au-c-toggle-switch {
   position: relative;
-  display: flex;
+  display: inline-flex;
+  gap: $au-unit-tiny;
   align-items: center;
 }
 
@@ -64,7 +65,6 @@ $au-toggle-switch-background-color-on-disabled: var(--au-gray-400) !default;
   color: var(--au-gray-700);
   font-family: var(--au-font);
   font-weight: var(--au-regular);
-  margin-left: $au-unit-tiny;
 
   .is-disabled & {
     color: var(--au-gray-600);
@@ -88,4 +88,14 @@ $au-toggle-switch-background-color-on-disabled: var(--au-gray-400) !default;
 .au-c-toggle-switch__input:focus + .au-c-toggle-switch__toggle {
   outline: var(--au-outline);
   outline-offset: var(--au-outline-offset);
+}
+
+// Alignment
+.au-c-toggle-switch--alignment-right {
+  flex-direction: row-reverse;
+}
+
+// Labelless
+.au-c-toggle-switch--labelless {
+  vertical-align: middle;
 }

--- a/app/styles/ember-appuniversum/_c-toggle-switch.scss
+++ b/app/styles/ember-appuniversum/_c-toggle-switch.scss
@@ -24,11 +24,17 @@ $au-toggle-switch-background-color-on-disabled: var(--au-gray-400) !default;
   display: inline-flex;
   gap: $au-unit-tiny;
   align-items: center;
+  color: var(--au-gray-900);
+  cursor: pointer;
+
+  &.is-disabled {
+    color: var(--au-gray-600);
+    cursor: not-allowed;
+  }
 }
 
 .au-c-toggle-switch__toggle {
   position: relative;
-  cursor: pointer;
   height: $au-toggle-switch-height - 0.4rem;
   width: $au-toggle-switch-width * 1.5;
   background-color: $au-toggle-switch-background-color;
@@ -52,22 +58,10 @@ $au-toggle-switch-background-color-on-disabled: var(--au-gray-400) !default;
   .is-disabled & {
     background-color: $au-toggle-switch-color-disabled;
     border-radius: $au-toggle-switch-border-radius;
-    cursor: not-allowed;
   }
 
   .is-disabled &:before {
     background-color: $au-toggle-switch-background-color-disabled;
-  }
-}
-
-.au-c-toggle-switch__label {
-  @include au-font-size(var(--au-h6));
-  color: var(--au-gray-700);
-  font-family: var(--au-font);
-  font-weight: var(--au-regular);
-
-  .is-disabled & {
-    color: var(--au-gray-600);
   }
 }
 

--- a/stories/5-components/Forms/AuToggleSwitch.stories.js
+++ b/stories/5-components/Forms/AuToggleSwitch.stories.js
@@ -4,6 +4,12 @@ export default {
   title: 'Components/Forms/AuToggleSwitch',
   argTypes: {
     label: { control: 'text', description: 'Set label text' },
+    alignment: {
+      control: 'select',
+      options: ['', 'left', 'right'],
+      description:
+        'Defines the alignment of the label',
+    },
     identifier: {
       control: 'text',
       description:
@@ -36,6 +42,7 @@ const Template = (args) => ({
   template: hbs`
     <AuToggleSwitch
       @label={{this.label}}
+      @alignment={{this.alignment}}
       @identifier={{this.identifier}}
       @disabled={{this.disabled}}
       @name={{this.name}}
@@ -48,6 +55,7 @@ const Template = (args) => ({
 export const Component = Template.bind({});
 Component.args = {
   label: 'Toggle this feature',
+  alignment: '',
   identifier: 'toggle',
   disabled: false,
   name: '',

--- a/stories/5-components/Forms/AuToggleSwitch.stories.js
+++ b/stories/5-components/Forms/AuToggleSwitch.stories.js
@@ -7,8 +7,7 @@ export default {
     alignment: {
       control: 'select',
       options: ['', 'left', 'right'],
-      description:
-        'Defines the alignment of the label',
+      description: 'Defines the alignment of the label',
     },
     identifier: {
       control: 'text',

--- a/stories/5-components/Forms/AuToggleSwitch.stories.js
+++ b/stories/5-components/Forms/AuToggleSwitch.stories.js
@@ -40,14 +40,13 @@ export default {
 const Template = (args) => ({
   template: hbs`
     <AuToggleSwitch
-      @label={{this.label}}
       @alignment={{this.alignment}}
       @identifier={{this.identifier}}
       @disabled={{this.disabled}}
       @name={{this.name}}
       @checked={{this.checked}}
       @onChange={{this.onchange}}
-    />`,
+    >{{this.label}}</AuToggleSwitch>`,
   context: args,
 });
 

--- a/tests/integration/components/au-toggle-switch-test.js
+++ b/tests/integration/components/au-toggle-switch-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { hasDeprecationStartingWith } from '../../helpers/deprecations';
 
 const TOGGLE_SWITCH = {
   LABEL: '[data-test-toggle-switch-label]',
@@ -46,6 +47,18 @@ module('Integration | Component | au-toggle-switch', function (hooks) {
 
   test('it shows the provided label text', async function (assert) {
     await render(hbs`<AuToggleSwitch @label="Choose me!" />`);
+
+    assert.dom(TOGGLE_SWITCH.LABEL).hasText('Choose me!');
+    assert.true(
+      hasDeprecationStartingWith(
+        '[AuToggleSwitch] The @label argument for this component is deprecated in favour of using block content.'
+      ),
+      '@label throws a deprecation warning'
+    );
+  });
+
+  test('it uses the block content as a label', async function (assert) {
+    await render(hbs`<AuToggleSwitch>Choose me!</AuToggleSwitch>`);
 
     assert.dom(TOGGLE_SWITCH.LABEL).hasText('Choose me!');
   });


### PR DESCRIPTION
Addition of the following functionality for the `AuToggleSwitch` component:
- The correct visualisation of the component if there is no label defined (this issue has already been fixed for `AuControlCheckbox` and `AuControlRadio`).
- The possibility of defining a certain alignment for the label (E.g. showing the label on the left of the actual toggle-switch).
- The possibility of passing content to the component as block (E.g. adding a loader to the toggle-switch) along with the existing `@label` method.

Together with some general adjustments:
-  Quick refactor from margin-based spacing to `gap` (already made within a few other components).

See https://github.com/appuniversum/ember-appuniversum/issues/385 for additional information.