### PR TITLE
Update of ember-focus-trap package and application of additional elements argument to modal component

### DIFF
--- a/addon/components/au-modal.hbs
+++ b/addon/components/au-modal.hbs
@@ -20,6 +20,7 @@
       tabindex="-1"
       {{focus-trap
         isActive=@modalOpen
+        additionalElements=(array '#ember-basic-dropdown-wormhole')
         focusTrapOptions=(hash
           initialFocus=this.initialFocus
           allowOutsideClick=true

--- a/addon/components/au-modal.hbs
+++ b/addon/components/au-modal.hbs
@@ -20,7 +20,7 @@
       tabindex="-1"
       {{focus-trap
         isActive=@modalOpen
-        additionalElements=(array "#ember-basic-dropdown-wormhole")
+        additionalElements=this.additionalElements
         focusTrapOptions=(hash
           initialFocus=this.initialFocus
           allowOutsideClick=true

--- a/addon/components/au-modal.hbs
+++ b/addon/components/au-modal.hbs
@@ -20,7 +20,7 @@
       tabindex="-1"
       {{focus-trap
         isActive=@modalOpen
-        additionalElements=(array '#ember-basic-dropdown-wormhole')
+        additionalElements=(array "#ember-basic-dropdown-wormhole")
         focusTrapOptions=(hash
           initialFocus=this.initialFocus
           allowOutsideClick=true

--- a/addon/components/au-modal.js
+++ b/addon/components/au-modal.js
@@ -2,6 +2,8 @@ import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
+const FOCUS_TRAP_ADDITIONAL_ELEMENTS = ['#ember-basic-dropdown-wormhole'];
+
 export default class AuModal extends Component {
   constructor() {
     super(...arguments);
@@ -34,6 +36,12 @@ export default class AuModal extends Component {
 
   get initialFocus() {
     return this.args.initialFocus ?? '.au-c-modal__title';
+  }
+
+  get additionalElements() {
+    return FOCUS_TRAP_ADDITIONAL_ELEMENTS.filter(
+      (element) => document.querySelector(element) !== null
+    );
   }
 
   @action

--- a/app/styles/ember-appuniversum/_p-ember-power-select.scss
+++ b/app/styles/ember-appuniversum/_p-ember-power-select.scss
@@ -70,6 +70,9 @@ $ember-power-select-opened-border-radius: 0; // Border radius of the side of the
 $ember-power-select-search-input-border-radius: 0.3rem;
 $ember-power-select-multiple-option-border-radius: $ember-power-select-default-border-radius;
 
+// Z-index
+$ember-power-select-dropdown-z-index: 10000; // Z-index of the dropdown when it is not rendered in place (needs to be higher then z-index of the modal component)
+
 // Other
 $ember-power-select-focus-box-shadow: none;
 $ember-power-select-dropdown-margin: 0; // Margin between the dropdown and the trigger
@@ -388,6 +391,7 @@ $ember-power-select-multiple-option-line-height: 1.45;
   box-shadow: $ember-power-select-dropdown-box-shadow;
   overflow: hidden;
   color: $ember-power-select-text-color;
+  z-index: $ember-power-select-dropdown-z-index;
 }
 
 .ember-power-select-dropdown.ember-basic-dropdown-content--above {
@@ -414,6 +418,7 @@ $ember-power-select-multiple-option-line-height: 1.45;
 .ember-power-select-dropdown.ember-basic-dropdown-content--in-place {
   // Dropdown when rendered in place
   width: 100%;
+  z-index: auto;
 }
 
 // Options

--- a/package-lock.json
+++ b/package-lock.json
@@ -15476,9 +15476,9 @@
       }
     },
     "ember-focus-trap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ember-focus-trap/-/ember-focus-trap-1.0.1.tgz",
-      "integrity": "sha512-ZUyq5ZkIuXp+ng9rCMkqBh36/V95PltL7iljStkma4+651xlAy3Z84L9WOu/uOJyVpNUxii8RJBbAySHV6c+RQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-focus-trap/-/ember-focus-trap-1.0.2.tgz",
+      "integrity": "sha512-/8Cx9KI7uqoMaNN4Iyxc24P2JIvAcCL3cI1tYdZRHTwTd1sG6esEZWOnpxZOSE7m4xHww8HVUSiXzgyqD8YIhA==",
       "requires": {
         "@embroider/addon-shim": "^1.0.0",
         "focus-trap": "^6.7.1"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ember-cli-htmlbars": "^6.2.0",
     "ember-data-table": "^2.1.0",
     "ember-file-upload": "^7.0.3",
-    "ember-focus-trap": "^1.0.1",
+    "ember-focus-trap": "^1.0.2",
     "ember-modifier": "^3.2.7",
     "ember-test-selectors": "^6.0.0",
     "inputmask": "^5.0.7",


### PR DESCRIPTION
This PR continues the works already done within https://github.com/appuniversum/ember-appuniversum/pull/391 but without the patching of the `ember-focus-trap` package:

- Update of the `ember-focus-trap` package (new release contains https://github.com/josemarluedke/ember-focus-trap/issues/71).
- Addition of `additionalElements` argument (with `#ember-basic-dropdown-wormhole` as a default) to the `AuModal` component to enable focus/tabbing within `ember-power-select` instances when following variables are met:
  - The `AuModal` instance has `@overflow` disabled.
  - The `ember-focus-trap` instance has `@renderInPlace` disabled.