### PR TITLE
Addition of action button within toaster (& alert) component

### DIFF
--- a/addon/components/au-alert.hbs
+++ b/addon/components/au-alert.hbs
@@ -1,9 +1,6 @@
 {{#if this.isVisible}}
   <div
-    class="au-c-alert
-      {{this.skin}}
-      {{this.size}}
-      {{if @isAToast 'au-c-alert--toast'}}"
+    class="au-c-alert {{this.skin}} {{this.size}}"
     role="alert"
     data-test-alert
     ...attributes

--- a/addon/components/au-alert.hbs
+++ b/addon/components/au-alert.hbs
@@ -1,6 +1,9 @@
 {{#if this.isVisible}}
   <div
-    class="au-c-alert {{this.skin}} {{this.size}} {{if @isAToast "au-c-alert--toast"}}"
+    class="au-c-alert
+      {{this.skin}}
+      {{this.size}}
+      {{if @isAToast 'au-c-alert--toast'}}"
     role="alert"
     data-test-alert
     ...attributes

--- a/addon/components/au-alert.hbs
+++ b/addon/components/au-alert.hbs
@@ -1,6 +1,6 @@
 {{#if this.isVisible}}
   <div
-    class="au-c-alert {{this.skin}} {{this.size}}"
+    class="au-c-alert {{this.skin}} {{this.size}} {{if @isAToast "au-c-alert--toast"}}"
     role="alert"
     data-test-alert
     ...attributes
@@ -14,11 +14,18 @@
         <AuIcon @icon={{@icon}} />
       </div>
     {{/if}}
-    <div class="au-c-alert__content">
-      {{#if @title}}
-        <p class="au-c-alert__title" data-test-alert-title>{{@title}}</p>
+    <div class="au-c-alert__container">
+      <div class="au-c-alert__content">
+        {{#if @title}}
+          <p class="au-c-alert__title" data-test-alert-title>{{@title}}</p>
+        {{/if}}
+        <div class="au-c-alert__message" data-test-alert-message>{{yield}}</div>
+      </div>
+      {{#if (has-block "action")}}
+        <div class="au-c-alert__action" data-test-alert-action>
+          {{yield to="action"}}
+        </div>
       {{/if}}
-      <div class="au-c-alert__message" data-test-alert-message>{{yield}}</div>
     </div>
     {{#if @closable}}
       <button

--- a/addon/components/au-toaster.hbs
+++ b/addon/components/au-toaster.hbs
@@ -1,17 +1,45 @@
 {{#if this.toaster.toasts.length}}
   <div class="au-c-toaster {{this.position}}">
     {{#each this.toaster.toasts as |toast|}}
-      <AuAlert
-        @title={{toast.title}}
-        @skin={{toast.options.type}}
-        @icon={{toast.options.icon}}
-        @size="small"
-        @closable={{toast.options.closable}}
-      >
-        {{#if toast.message}}
-          <p>{{toast.message}}</p>
-        {{/if}}
-      </AuAlert>
+      {{#if toast.options.action}}
+        <AuAlert
+          @title={{toast.title}}
+          @skin={{toast.options.type}}
+          @icon={{toast.options.icon}}
+          @size="small"
+          @closable={{toast.options.closable}}
+          @isAToast={{true}}
+        >
+          <:default>
+            {{#if toast.message}}
+              <p>{{toast.message}}</p>
+            {{/if}}
+          </:default>
+          <:action>
+            <AuButton
+              @skin="link"
+              @icon={{toast.options.action.icon}}
+              @alert={{toast.options.action.alert}}
+              {{on "click" toast.options.action.handler}}
+            >
+              {{toast.options.action.text}}
+            </AuButton>
+          </:action>
+        </AuAlert>
+      {{else}}
+        <AuAlert
+          @title={{toast.title}}
+          @skin={{toast.options.type}}
+          @icon={{toast.options.icon}}
+          @size="small"
+          @closable={{toast.options.closable}}
+          @isAToast={{true}}
+        >
+          {{#if toast.message}}
+            <p>{{toast.message}}</p>
+          {{/if}}
+        </AuAlert>
+      {{/if}}
     {{/each}}
   </div>
 {{/if}}

--- a/addon/components/au-toaster.hbs
+++ b/addon/components/au-toaster.hbs
@@ -8,7 +8,7 @@
           @icon={{toast.options.icon}}
           @size="small"
           @closable={{toast.options.closable}}
-          @isAToast={{true}}
+          class="au-c-alert--toast"
         >
           <:default>
             {{#if toast.message}}
@@ -33,7 +33,7 @@
           @icon={{toast.options.icon}}
           @size="small"
           @closable={{toast.options.closable}}
-          @isAToast={{true}}
+          class="au-c-alert--toast"
         >
           {{#if toast.message}}
             <p>{{toast.message}}</p>

--- a/addon/services/toaster.js
+++ b/addon/services/toaster.js
@@ -2,6 +2,7 @@ import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 import { A } from '@ember/array';
+import { assert } from '@ember/debug';
 
 export default class ToasterService extends Service {
   @tracked toasts = A([]);
@@ -14,6 +15,20 @@ export default class ToasterService extends Service {
 
     if (typeof toast.options.closable === 'undefined') {
       toast.options.closable = true;
+    }
+
+    if (typeof toast.options.action === 'undefined') {
+      toast.options.action = null;
+    } else {
+      assert(
+        'Toaster (service): No text for the action button was defined.',
+        Object.hasOwn(toast.options.action, 'text')
+      );
+
+      assert(
+        'Toaster (service): No handler for the action button was defined.',
+        Object.hasOwn(toast.options.action, 'handler')
+      );
     }
 
     this.toasts.pushObject(toast);

--- a/app/styles/ember-appuniversum/_c-alert.scss
+++ b/app/styles/ember-appuniversum/_c-alert.scss
@@ -31,6 +31,7 @@ $au-alert-radius: var(--au-radius) !default;
 .au-c-alert {
   color: $au-alert-color;
   display: flex;
+  gap: $au-unit-large * 0.5;
   font-family: var(--au-font);
   font-size: $au-alert-font-size;
   padding: $au-unit;
@@ -53,7 +54,6 @@ $au-alert-radius: var(--au-radius) !default;
   border-radius: $au-unit-large;
   height: $au-unit-large - 0.1rem; // compensate for visual distortion of perfect circle
   width: $au-unit-large;
-  margin-right: $au-unit-large * 0.5;
 
   display: flex;
   align-items: center;
@@ -65,6 +65,14 @@ $au-alert-radius: var(--au-radius) !default;
     width: $au-alert-icon-size;
     bottom: 0;
   }
+}
+
+.au-c-alert__container {
+  display: flex;
+  gap: $au-unit-large * 0.5;
+  flex-direction: row;
+  align-items: center;
+  flex-grow: 1;
 }
 
 .au-c-alert__content {
@@ -110,12 +118,12 @@ $au-alert-radius: var(--au-radius) !default;
 }
 
 .au-c-alert--small {
+  gap: $au-unit * 0.5;
   padding: $au-unit-small;
 
   .au-c-alert__icon {
     height: $au-unit - 0.1rem; // compensate for visual distortion of perfect circle
     width: $au-unit;
-    margin-right: $au-unit * 0.5;
   }
 
   .au-c-icon {
@@ -160,5 +168,22 @@ $au-alert-radius: var(--au-radius) !default;
     .au-c-icon {
       fill: $au-alert-error-icon-color;
     }
+  }
+}
+
+.au-c-alert--toast {
+  .au-c-alert__container {
+    gap: $au-unit-tiny;
+    flex-direction: column;
+    align-items: normal;
+    justify-content: center;
+  }
+
+  .au-c-alert__content {
+    flex-grow: 0;
+  }
+
+  .au-c-alert__action {
+    margin-left: -($au-unit-tiny + 0.2rem); // use negative horizontal button padding + button border width for better alignment
   }
 }

--- a/stories/5-components/Notifications/AuAlert.stories.js
+++ b/stories/5-components/Notifications/AuAlert.stories.js
@@ -46,8 +46,42 @@ const Template = (args) => ({
   context: args,
 });
 
-export const Component = Template.bind({});
-Component.args = {
+const TemplateWithActionButton = (args) => ({
+  template: hbs`
+    <AuAlert
+      @title={{this.title}}
+      @skin={{this.skin}}
+      @icon={{this.icon}}
+      @size={{this.size}}
+      @closable={{this.closable}}
+      @onClose={{this.onClose}}
+    >
+      <:default>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
+      </:default>
+      <:action>
+        <AuButton
+          @skin="primary"
+          @icon="download"
+        >
+          Action button
+        </AuButton>
+      </:action>
+    </AuAlert>`,
+  context: args,
+});
+
+export const Alert = Template.bind({});
+Alert.args = {
+  title: 'Alert',
+  skin: 'warning',
+  icon: 'download',
+  size: 'default',
+  closable: false,
+};
+
+export const AlertWithActionButton = TemplateWithActionButton.bind({});
+AlertWithActionButton.args = {
   title: 'Alert',
   skin: 'warning',
   icon: 'download',

--- a/tests/dummy/app/components/au-toast-demo.hbs
+++ b/tests/dummy/app/components/au-toast-demo.hbs
@@ -64,6 +64,15 @@
 
     <AuButton @skin="secondary" {{on "click" this.triggerLoadingToast}}>Trigger
       loading toast</AuButton>
+
+    <AuHr />
+
+    <p class="au-u-margin-bottom-small">With action button:
+      <AuPill>{{"this.toaster.success('Message','Notify',{ action: { icon: 'download', text: 'Action button', handler: this.triggerToast } });"}}</AuPill>.</p>
+
+    <AuButton @skin="secondary" {{on "click" this.triggerToastWithActionButton}}>
+      Trigger success toast with action button
+    </AuButton>
   </div>
 
   <div class="au-o-flow au-o-flow--tiny">

--- a/tests/dummy/app/components/au-toast-demo.hbs
+++ b/tests/dummy/app/components/au-toast-demo.hbs
@@ -68,9 +68,13 @@
     <AuHr />
 
     <p class="au-u-margin-bottom-small">With action button:
-      <AuPill>{{"this.toaster.success('Message','Notify',{ action: { icon: 'download', text: 'Action button', handler: this.triggerToast } });"}}</AuPill>.</p>
+      <AuPill
+      >{{"this.toaster.success('Message','Notify',{ action: { icon: 'download', text: 'Action button', handler: this.triggerToast } });"}}</AuPill>.</p>
 
-    <AuButton @skin="secondary" {{on "click" this.triggerToastWithActionButton}}>
+    <AuButton
+      @skin="secondary"
+      {{on "click" this.triggerToastWithActionButton}}
+    >
       Trigger success toast with action button
     </AuButton>
   </div>

--- a/tests/dummy/app/components/au-toast-demo.js
+++ b/tests/dummy/app/components/au-toast-demo.js
@@ -31,6 +31,17 @@ export default class AuToastDemo extends Component {
   }
 
   @action
+  triggerToastWithActionButton() {
+    this.toaster.success('Message', 'Notify with action', {
+      action: {
+        icon: 'download',
+        text: 'Action button',
+        handler: this.triggerToast,
+      }
+    });
+  }
+
+  @action
   triggerTimeoutToast() {
     this.toaster.notify('Message', 'Timeout', {
       timeOut: 3000,

--- a/tests/dummy/app/components/au-toast-demo.js
+++ b/tests/dummy/app/components/au-toast-demo.js
@@ -37,7 +37,7 @@ export default class AuToastDemo extends Component {
         icon: 'download',
         text: 'Action button',
         handler: this.triggerToast,
-      }
+      },
     });
   }
 


### PR DESCRIPTION
Addition of the following functionality for the `AuToaster` & `AuAlert` components:
* `AuAlert`: inclusion of a possible action block. I've added this because we'll need this anyway in the near future within Kaleidos & this makes implementing functionality within `AuToaster` a bit easier. You can check Storybook for a new example regarding that.
* `AuToaster`: inclusion of possible action configuration within the toaster options.

What is currently missing (within draft):
* Some finalization & code clean-up (see remarks)
* Accompanying tests

PS: @Windvis, I've checked your comment at https://github.com/appuniversum/ember-appuniversum/issues/397#issuecomment-1621658212. That seems like a great method to implement similar changes, but I don't think this has much advantage over the current version/changes within this draft? Feel free to correct me if this is not the case!