### PR TITLE
List ember-concurrency as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14486,7 +14486,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-2.3.7.tgz",
       "integrity": "sha512-sz6sTIXN/CuLb5wdpauFa+rWXuvXXSnSHS4kuNzU5GSMDX1pLBWSuovoUk61FUe6CYRqBmT1/UushObwBGickQ==",
-      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/types": "^7.12.13",
@@ -14502,7 +14501,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
           "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-          "optional": true,
           "requires": {
             "debug": "^4.1.1",
             "heimdalljs": "^0.2.3",
@@ -14517,7 +14515,6 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
           "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-          "optional": true,
           "requires": {
             "async-disk-cache": "^2.0.0",
             "async-promise-queue": "^1.0.3",
@@ -14536,7 +14533,6 @@
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
           "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-          "optional": true,
           "requires": {
             "broccoli-node-api": "^1.7.0",
             "broccoli-output-wrapper": "^3.2.5",
@@ -14550,8 +14546,7 @@
             "promise-map-series": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-              "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-              "optional": true
+              "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA=="
             }
           }
         },
@@ -14559,7 +14554,6 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
           "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-          "optional": true,
           "requires": {
             "errlop": "^2.0.0",
             "semver": "^6.3.0"
@@ -14568,8 +14562,7 @@
             "semver": {
               "version": "6.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "optional": true
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
             }
           }
         },
@@ -14577,7 +14570,6 @@
           "version": "5.7.2",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
           "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-          "optional": true,
           "requires": {
             "@ember/edition-utils": "^1.2.0",
             "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
@@ -14601,7 +14593,6 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
           "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
-          "optional": true,
           "requires": {
             "resolve-package-path": "^3.1.0",
             "semver": "^7.3.4",
@@ -14612,7 +14603,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
           "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-          "optional": true,
           "requires": {
             "@types/symlink-or-copy": "^1.2.0",
             "heimdalljs-logger": "^0.1.7",
@@ -14625,7 +14615,6 @@
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
           "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-          "optional": true,
           "requires": {
             "binaryextensions": "^2.1.2",
             "editions": "^2.2.0",
@@ -14636,7 +14625,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
           "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "optional": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
@@ -14646,7 +14634,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
           "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-          "optional": true,
           "requires": {
             "path-root": "^0.1.1",
             "resolve": "^1.17.0"
@@ -14656,7 +14643,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
           "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-          "optional": true,
           "requires": {
             "debug": "^4.1.1",
             "heimdalljs": "^0.2.6",
@@ -14669,7 +14655,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
           "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "optional": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "ember-auto-import": "^2.5.0",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.2.0",
+    "ember-concurrency": "2.x || ^3.1.0",
     "ember-data-table": "^2.1.0",
     "ember-file-upload": "^7.0.3",
     "ember-focus-trap": "^1.0.2",
@@ -127,7 +128,6 @@
     "webpack": "^5.75.0"
   },
   "optionalDependencies": {
-    "ember-concurrency": "2.x",
     "ember-power-select": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x"
   },
   "peerDependencies": {


### PR DESCRIPTION
We now use it in the toaster service as well, so we might consider it no longer optional. We also widen the range so v3 is supported as well.