### PR TITLE
Clicking issue for wormhole elements/components within the modal component

### DIFF
--- a/addon/components/au-modal.hbs
+++ b/addon/components/au-modal.hbs
@@ -20,6 +20,7 @@
           initialFocus=this.initialFocus
           fallbackFocus=this.fallbackFocus
           escapeDeactivates=this.handleEscapePress
+          allowOutsideClick=true
         )
       }}
       data-test-modal


### PR DESCRIPTION
It seems like the `allowOutsideClick` argument was wrongly removed (my bad!) within https://github.com/appuniversum/ember-appuniversum/pull/412 as it creates clicking issues within set-ups where elements/components are displayed through a wormhole within the modal component.