### PR TITLE
Add Ember v5 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "ember-power-select": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"


### PR DESCRIPTION
We were already testing against Ember v5, so this simply allows new projects to use Appuniversum without needing overrides.