### PR TITLE
Refactor the AuDateInput component

### DIFF
--- a/addon/components/au-date-input.hbs
+++ b/addon/components/au-date-input.hbs
@@ -1,15 +1,11 @@
-<span class="au-c-input-wrapper {{this.width}}">
-  <input
-    class="au-c-input
-      {{this.error}}
-      {{this.warning}}
-      {{this.width}}
-      {{this.disabled}}"
-    disabled={{@disabled}}
-    placeholder="DD-MM-JJJJ"
-    autocomplete="off"
-    ...attributes
-    {{this.dateInput value=@value prefillYear=@prefillYear onChange=@onChange}}
-  />
-  <AuIcon @icon="calendar" @alignment="left" />
-</span>
+<AuInput
+  @disabled={{@disabled}}
+  @error={{@error}}
+  @icon="calendar"
+  @warning={{@warning}}
+  @width={{@width}}
+  autocomplete="off"
+  placeholder="DD-MM-JJJJ"
+  {{this.dateInput value=@value prefillYear=@prefillYear onChange=@onChange}}
+  ...attributes
+/>

--- a/addon/components/au-date-input.js
+++ b/addon/components/au-date-input.js
@@ -11,28 +11,6 @@ import {
 
 export default class AuDateInputComponent extends Component {
   dateInput = DateInputModifier;
-
-  // These getters need to be kept in sync with the AuInput component.
-  // Once we refactor that component so it no longer uses `<Input>` we can remove the duplication and wrap AuInput instead.
-  get width() {
-    if (this.args.width == 'block') return 'au-c-input--block';
-    else return '';
-  }
-
-  get error() {
-    if (this.args.error) return 'au-c-input--error';
-    else return '';
-  }
-
-  get warning() {
-    if (this.args.warning) return 'au-c-input--warning';
-    else return '';
-  }
-
-  get disabled() {
-    if (this.args.disabled) return 'is-disabled';
-    else return '';
-  }
 }
 
 class DateInputModifier extends Modifier {


### PR DESCRIPTION
We can now use the AuInput internally which removes the duplicated code.