### PR TITLE
Deprecate the `tertiary` button skin

### DIFF
--- a/addon/components/au-accordion.hbs
+++ b/addon/components/au-accordion.hbs
@@ -9,7 +9,7 @@
     <Group>
       <div>
         <AuButton
-          @skin="tertiary"
+          @skin="link"
           aria-expanded="{{if this.accordionOpen 'true' 'false'}}"
           data-test-accordion-button
         >

--- a/addon/components/au-button.js
+++ b/addon/components/au-button.js
@@ -1,9 +1,23 @@
+import { deprecate } from '@ember/debug';
 import Component from '@glimmer/component';
 
 const SKINS = ['primary', 'secondary', 'naked', 'link', 'link-secondary'];
 
 export default class AuButton extends Component {
   get skin() {
+    deprecate(
+      '[AuButton] The `tertiary` skin is deprecated. Use the `link` skin instead.',
+      this.args.skin !== 'tertiary',
+      {
+        id: '@appuniversum/ember-appuniversum.au-button-tertiary',
+        until: '3.0.0',
+        for: '@appuniversum/ember-appuniversum',
+        since: {
+          enabled: '2.14.0',
+        },
+      },
+    );
+
     if (SKINS.includes(this.args.skin)) return this.args.skin;
     else if (this.args.skin === 'tertiary') return 'link'; // DEPRECATED
     else return 'primary';

--- a/addon/components/au-card.hbs
+++ b/addon/components/au-card.hbs
@@ -21,7 +21,7 @@
         <AuButton
           class="au-c-card__toggle"
           @size="small"
-          @skin="tertiary"
+          @skin="link"
           aria-hidden="true"
           focusable="false"
           aria-expanded="{{if this.sectionOpen 'true' 'false'}}"
@@ -52,7 +52,7 @@
         <AuButton
           class="au-c-card__toggle"
           @size="small"
-          @skin="tertiary"
+          @skin="link"
           aria-hidden="true"
           focusable="false"
           aria-expanded="{{if this.sectionOpen 'true' 'false'}}"

--- a/addon/components/au-data-table/number-pagination.hbs
+++ b/addon/components/au-data-table/number-pagination.hbs
@@ -10,26 +10,27 @@
     {{#if this.hasMultiplePages}}
       {{#unless this.isFirstPage}}
         <li class="au-c-pagination__list-item">
-          <button
+          <AuButton
+            @skin="link"
+            @icon="nav-left"
             {{action "changePage" this.links.prev}}
-            class="au-c-button au-c-button--tertiary"
           >
-            <AuIcon @icon="nav-left" @alignment="left" />
             vorige
             <span class="au-u-hidden-visually"> {{this.pageSize}} rijen</span>
-          </button>
+          </AuButton>
         </li>
       {{/unless}}
       {{#unless this.isLastPage}}
         <li class="au-c-pagination__list-item">
-          <button
+          <AuButton
+            @skin="link"
+            @icon="nav-right"
+            @iconAlignment="right"
             {{action "changePage" this.links.next}}
-            class="au-c-button au-c-button--tertiary"
           >
             volgende
             <span class="au-u-hidden-visually"> {{this.pageSize}} rijen</span>
-            <AuIcon @icon="nav-right" @alignment="right" />
-          </button>
+          </AuButton>
         </li>
       {{/unless}}
     {{/if}}

--- a/stories/5-components/Brand/AuMainHeader.stories.js
+++ b/stories/5-components/Brand/AuMainHeader.stories.js
@@ -28,7 +28,7 @@ const Template = (args) => ({
       @contactRoute={{this.contactRoute}}
     >
       <AuDropdown @title="Demo dropdown" @alignment="right" role="menu">
-        <AuButton @skin="tertiary" @icon="logout" role="menuitem">
+        <AuButton @skin="link" @icon="logout" role="menuitem">
           Afmelden
         </AuButton>
       </AuDropdown>

--- a/stories/5-components/Content/AuCard.stories.js
+++ b/stories/5-components/Content/AuCard.stories.js
@@ -135,7 +135,7 @@ const EditableTemplate = (args) => ({
         <AuHeading @level="4" @skin="5">Card – editable</AuHeading>
       </Group>
       <Group>
-        <AuButton @skin="tertiary" @icon="pencil" @iconAlignment="right">
+        <AuButton @skin="link" @icon="pencil" @iconAlignment="right">
           Bewerk
         </AuButton>
       </Group>

--- a/stories/5-components/Navigation/AuDropdown.stories.js
+++ b/stories/5-components/Navigation/AuDropdown.stories.js
@@ -59,10 +59,10 @@ const Template = (args) => ({
       @onClose={{this.onClose}}
       role="menu"
     >
-      <AuButton @skin="tertiary" @icon="switch" role="menuitem">
+      <AuButton @skin="link" @icon="switch" role="menuitem">
         Switch profile
       </AuButton>
-      <AuButton @skin="tertiary" @icon="logout" role="menuitem">
+      <AuButton @skin="link" @icon="logout" role="menuitem">
         Afmelden
       </AuButton>
     </AuDropdown>`,
@@ -83,24 +83,24 @@ const TemplateSeparator = (args) => ({
       @onClose={{this.onClose}}
       role="menu"
     >
-      <AuButton @skin="tertiary" role="menuitem">
+      <AuButton @skin="link" role="menuitem">
         Agendapunt toevoegen
       </AuButton>
-      <AuButton @skin="tertiary" role="menuitem">
+      <AuButton @skin="link" role="menuitem">
         Beslissingen bekijken
       </AuButton>
-      <AuButton @skin="tertiary" role="menuitem">
+      <AuButton @skin="link" role="menuitem">
         Download alle documenten
       </AuButton>
       <AuHr />
-      <AuButton @skin="tertiary" role="menuitem">
+      <AuButton @skin="link" role="menuitem">
         Vergadering wijzigen
       </AuButton>
-      <AuButton @skin="tertiary" role="menuitem">
+      <AuButton @skin="link" role="menuitem">
         Alles formeel goedkeuren
       </AuButton>
       <AuHr />
-      <AuButton @alert="true" @skin="tertiary" @icon="bin" role="menuitem">
+      <AuButton @alert="true" @skin="link" @icon="bin" role="menuitem">
         Verwijder
       </AuButton>
     </AuDropdown>`,

--- a/stories/5-components/Tables/AuDataTable.stories.js
+++ b/stories/5-components/Tables/AuDataTable.stories.js
@@ -11,7 +11,8 @@ export default {
 const Template = (args) => ({
   template: hbs`
     <AuDataTable
-      @content={{this.model}}
+      @content={{this.getData this.page this.itemsPerPage this.totalItems}}
+      @page={{this.page}}
       @fields="title description"
       @noDataMessage="Geen documenten"
       @sort={{this.sort}}
@@ -53,8 +54,57 @@ const Template = (args) => ({
         </c.body>
       </t.content>
     </AuDataTable>`,
-  context: args,
+  context: {
+    ...args,
+    getData: function (page = 0, perPage = 5, totalItems = 100) {
+      const baseNumber = perPage * page + 1;
+      const lastPage = totalItems / perPage - 1;
+
+      let data = [];
+
+      if (page <= lastPage && page >= 0) {
+        data = Array(perPage)
+          .fill(null)
+          .map((_, index) => {
+            return {
+              title: `title ${index + baseNumber}`,
+              description: `description ${index + baseNumber}`,
+            };
+          });
+      }
+
+      data.meta = {
+        count: totalItems,
+        pagination: {
+          first: {
+            number: 0,
+          },
+          last: {
+            number: lastPage,
+          },
+        },
+      };
+
+      if (page > 0) {
+        data.meta.pagination.prev = {
+          number: page - 1,
+        };
+      }
+
+      if (page < lastPage) {
+        data.meta.pagination.next = {
+          number: page + 1,
+        };
+      }
+
+      return data;
+    },
+  },
 });
 
 export const Component = Template.bind({});
-Component.args = {};
+Component.args = {
+  page: 0,
+  itemsPerPage: 5,
+  totalItems: 100,
+};

--- a/stories/6-patterns/forms.stories.js
+++ b/stories/6-patterns/forms.stories.js
@@ -91,7 +91,7 @@ const Template = (args) => ({
           <AuButton>
             Submit
           </AuButton>
-          <AuButton @skin="tertiary">
+          <AuButton @skin="link">
             Cancel
           </AuButton>
         </AuButtonGroup>
@@ -198,7 +198,7 @@ const TemplateInline = (args) => ({
           <AuButton>
             Submit
           </AuButton>
-          <AuButton @skin="tertiary">
+          <AuButton @skin="link">
             Cancel
           </AuButton>
         </AuButtonGroup>
@@ -299,7 +299,7 @@ const TemplatePre = (args) => ({
           <AuButton>
             Submit
           </AuButton>
-          <AuButton @skin="tertiary">
+          <AuButton @skin="link">
             Cancel
           </AuButton>
         </AuButtonGroup>

--- a/stories/7-templates/AppBreadcrumbs.stories.js
+++ b/stories/7-templates/AppBreadcrumbs.stories.js
@@ -12,7 +12,7 @@ const Template = (args) => ({
     <AuApp>
       <AuMainHeader @brandLink="https://www.vlaanderen.be/nl" @homeRoute="docs.templates.app-sidebar" @appTitle="App title" @contactRoute="docs.templates.app-sidebar">
         <AuDropdown @title="Aangemeld als ..." @alignment="right" role="menu">
-          <AuButton @skin="tertiary" role="menuitem">
+          <AuButton @skin="link" role="menuitem">
             <AuIcon @icon="logout" @alignment="left" />Afmelden
           </AuButton>
         </AuDropdown>

--- a/stories/7-templates/AppEditor.stories.js
+++ b/stories/7-templates/AppEditor.stories.js
@@ -42,15 +42,15 @@ const Template = (args) => ({
             </Group>
             <Group class="au-c-toolbar__group--actions">
               <AuDropdown @title="Bestand acties" @alignment="right" role="menu">
-                <AuButton @skin="tertiary" role="menuitem">
+                <AuButton @skin="link" role="menuitem">
                   <AuIcon @icon="copy" @alignment="left" />
                   Kopieer agendapunt
                 </AuButton>
-                <AuButton @skin="tertiary" role="menuitem">
+                <AuButton @skin="link" role="menuitem">
                   <AuIcon @icon="export" @alignment="left" />
                   Exporteer als HTML
                 </AuButton>
-                <AuButton @skin="tertiary" @alert="true" role="menuitem">
+                <AuButton @skin="link" @alert="true" role="menuitem">
                   <AuIcon @icon="bin" @alignment="left" />
                   Naar prullenmand
                 </AuButton>

--- a/stories/7-templates/AppSidebar.stories.js
+++ b/stories/7-templates/AppSidebar.stories.js
@@ -12,7 +12,7 @@ const Template = (args) => ({
     <AuApp>
       <AuMainHeader @brandLink="https://www.vlaanderen.be/nl" @homeRoute="docs.templates.app-sidebar" @appTitle="App title" @contactRoute="docs.templates.app-sidebar">
         <AuDropdown @title="Aangemeld als ..." @alignment="right" role="menu">
-          <AuButton @skin="tertiary" role="menuitem">
+          <AuButton @skin="link" role="menuitem">
             <AuIcon @icon="logout" @alignment="left" />Afmelden
           </AuButton>
         </AuDropdown>

--- a/tests/integration/components/au-button-test.js
+++ b/tests/integration/components/au-button-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { hasDeprecationStartingWith } from '../../helpers/deprecations';
 
 module('Integration | Component | au-button', function (hooks) {
   setupRenderingTest(hooks);
@@ -44,5 +45,19 @@ module('Integration | Component | au-button', function (hooks) {
 
     this.set('isLoading', true);
     assert.dom('[data-test-button]').isDisabled();
+  });
+
+  test('it shows a deprecation warning when the tertiary skin is used', async function (assert) {
+    await render(hbs`
+      <AuButton @skin="tertiary">
+        template block text
+      </AuButton>
+    `);
+
+    assert.true(
+      hasDeprecationStartingWith(
+        '[AuButton] The `tertiary` skin is deprecated. Use the `link` skin instead.',
+      ),
+    );
   });
 });


### PR DESCRIPTION
It seems this was marked as deprecated in the code, but a deprecation message was never added. This adds that so we can remove it in v3.

This is an alias for the `link` skin so it can simply be renamed.