### PR TITLE
Add a `{{au-date-input}}` modifier

### DIFF
--- a/addon/components/au-date-input.hbs
+++ b/addon/components/au-date-input.hbs
@@ -6,6 +6,6 @@
   @width={{@width}}
   autocomplete="off"
   placeholder="DD-MM-JJJJ"
-  {{this.dateInput value=@value prefillYear=@prefillYear onChange=@onChange}}
+  {{au-date-input value=@value prefillYear=@prefillYear onChange=@onChange}}
   ...attributes
 />

--- a/addon/modifiers/au-date-input.js
+++ b/addon/modifiers/au-date-input.js
@@ -1,19 +1,14 @@
-import Component from '@glimmer/component';
-import { assert } from '@ember/debug';
-import { registerDestructor } from '@ember/destroyable';
-import Modifier from 'ember-modifier';
-import Inputmask from 'inputmask';
 import {
   toIsoDateString,
   isIsoDateString,
   isoDateToBelgianFormat,
 } from '@appuniversum/ember-appuniversum/utils/date';
+import { assert } from '@ember/debug';
+import { registerDestructor } from '@ember/destroyable';
+import Modifier from 'ember-modifier';
+import Inputmask from 'inputmask';
 
-export default class AuDateInputComponent extends Component {
-  dateInput = DateInputModifier;
-}
-
-class DateInputModifier extends Modifier {
+export default class AuDateInputModifier extends Modifier {
   input;
   argValue;
   argOnChange;

--- a/app/modifiers/au-date-input.js
+++ b/app/modifiers/au-date-input.js
@@ -1,0 +1,1 @@
+export { default } from '@appuniversum/ember-appuniversum/modifiers/au-date-input';

--- a/stories/5-components/Forms/AuDateInput.stories.js
+++ b/stories/5-components/Forms/AuDateInput.stories.js
@@ -35,7 +35,18 @@ const Template = (args) => ({
       @disabled={{this.disabled}}
       @prefillYear={{this.prefillYear}}
       @onChange={{this.onChange}}
-    />`,
+    />
+
+    <AuAlert @icon="circle-info" @size="small" class="au-u-margin-top au-u-max-width-small">
+      <AuContent @skin="small">
+        <p>If you need more control over the styling of the input field,
+        you can use the <AuPill>{{"{{au-date-input}}"}}</AuPill> modifier.</p>
+
+        <p>It provides the same functionality (without the styling), so you can apply
+        it to your own input component.</p>
+      </AuContent>
+    </AuAlert>
+    `,
   context: args,
 });
 

--- a/tests/integration/modifiers/au-date-input-test.js
+++ b/tests/integration/modifiers/au-date-input-test.js
@@ -1,0 +1,71 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { typeIn, fillIn, render, triggerKeyEvent } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Modifier | au-date-input', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it accepts an iso date string or date object as a value', async function (assert) {
+    this.value = '2023-02-02';
+
+    await render(hbs`
+      <AuInput data-test-date-input {{au-date-input value=this.value}} />
+    `);
+
+    assert.dom('[data-test-date-input]').hasValue('02-02-2023');
+
+    this.set('value', new Date(2024, 5, 3));
+    assert.dom('[data-test-date-input]').hasValue('03-06-2024');
+
+    this.set('value', undefined);
+    assert.dom('[data-test-date-input]').hasNoValue();
+  });
+
+  test('it calls @onChange with the correct date', async function (assert) {
+    this.onChange = (isoDate, date) => {
+      assert.step(isoDate);
+      assert.step((date instanceof Date).toString());
+    };
+
+    await render(hbs`
+      <AuInput data-test-date-input {{au-date-input onChange=this.onChange}} />
+    `);
+
+    await fillIn('[data-test-date-input]', '0202202');
+    await typeIn('[data-test-date-input]', '3'); // fillIn alone doesn't do the trick, but typeIn has issues when typing all the characters..
+
+    assert.verifySteps(
+      ['2023-02-02', 'true'],
+      '@onChange returns an iso string and date instance',
+    );
+  });
+
+  test('it calls @onChange with `null` if the input is cleared', async function (assert) {
+    this.onChange = (isoDate, date) => {
+      assert.step((isoDate === null).toString());
+      assert.step((date === null).toString());
+    };
+
+    await render(hbs`
+      <AuInput data-test-date-input {{au-date-input value="2023-02-02" onChange=this.onChange}} />
+    `);
+
+    let input = document.querySelector('[data-test-date-input]');
+
+    await clearInput(input);
+    assert.verifySteps(
+      ['true', 'true'],
+      '`@onChange` returns `null` if the input is cleared',
+    );
+  });
+});
+
+async function clearInput(input) {
+  // Focus seems to be needed to make the backspace work
+  input.focus();
+
+  while (input.value.length > 0) {
+    await triggerKeyEvent(input, 'keydown', 'Backspace');
+  }
+}


### PR DESCRIPTION
This allows projects to style their own input in case the `AuDateInput` component isn't flexible enough.

Closes #392 