### PR TITLE
Deprecate the `AuTextarea` `@value` argument

### DIFF
--- a/addon/components/au-textarea.hbs
+++ b/addon/components/au-textarea.hbs
@@ -1,12 +1,26 @@
-<Textarea
-  class="au-c-textarea
-    {{this.error}}
-    {{this.warning}}
-    {{this.width}}
-    {{this.disabled}}"
-  disabled={{@disabled}}
-  @value={{@value}}
-  ...attributes
->
-  {{yield}}
-</Textarea>
+{{#if this.useDeprecatedTextarea}}
+  <Textarea
+    class="au-c-textarea
+      {{this.error}}
+      {{this.warning}}
+      {{this.width}}
+      {{this.disabled}}"
+    disabled={{@disabled}}
+    @value={{@value}}
+    ...attributes
+  >
+    {{yield}}
+  </Textarea>
+{{else}}
+  <textarea
+    class="au-c-textarea
+      {{this.error}}
+      {{this.warning}}
+      {{this.width}}
+      {{this.disabled}}"
+    disabled={{@disabled}}
+    ...attributes
+  >
+    {{~yield~}}
+  </textarea>
+{{/if}}

--- a/addon/components/au-textarea.js
+++ b/addon/components/au-textarea.js
@@ -1,6 +1,28 @@
 import Component from '@glimmer/component';
+import { deprecate } from '@ember/debug';
 
 export default class AuTextarea extends Component {
+  constructor() {
+    super(...arguments);
+
+    deprecate(
+      '[AuTextarea] The `@value` argument is deprecated. Use the `value` attribute and the `{{on}}` modifier instead.',
+      !this.useDeprecatedTextarea,
+      {
+        id: '@appuniversum/ember-appuniversum.au-textarea-value-argument',
+        until: '3.0.0',
+        for: '@appuniversum/ember-appuniversum',
+        since: {
+          enabled: '2.15.0',
+        },
+      },
+    );
+  }
+
+  get useDeprecatedTextarea() {
+    return 'value' in this.args;
+  }
+
   get width() {
     if (this.args.width == 'block') return 'au-c-textarea--block';
     else return '';

--- a/stories/5-components/Forms/AuTextarea.stories.js
+++ b/stories/5-components/Forms/AuTextarea.stories.js
@@ -15,6 +15,12 @@ export default {
       control: 'boolean',
       description: 'Adds a disabled state to the textarea',
     },
+    value: {
+      control: 'text',
+    },
+    handleChange: {
+      action: 'change',
+    },
   },
   parameters: {
     layout: 'padded',
@@ -24,13 +30,14 @@ export default {
 const Template = (args) => ({
   template: hbs`
     <AuTextarea
-      id={{this.id}}
       @width={{this.width}}
       @error={{this.error}}
       @warning={{this.warning}}
       @disabled={{this.disabled}}
-    >
-    </AuTextarea>`,
+      id={{this.id}}
+      value={{this.value}}
+      {{on "change" this.handleChange}}
+    />`,
   context: args,
 });
 

--- a/tests/integration/components/au-textarea-test.js
+++ b/tests/integration/components/au-textarea-test.js
@@ -1,17 +1,82 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { fillIn, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { hasDeprecationStartingWith } from '../../helpers/deprecations';
 
 module('Integration | Component | au-textarea', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  test('it can be disabled', async function (assert) {
+    this.isDisabled = true;
+    await render(hbs`<AuTextarea @disabled={{this.isDisabled}} />`);
 
-    await render(hbs`<AuTextarea />`);
+    assert.dom('textarea').isDisabled();
 
-    assert.dom(this.element).hasText('');
+    this.set('isDisabled', false);
+    assert.dom('textarea').isNotDisabled();
+  });
+
+  test('it updates the `@value` through 2-way-binding', async function (assert) {
+    this.value = '';
+
+    await render(hbs`<AuTextarea @value={{this.value}} />`);
+
+    await fillIn('textarea', 'foo');
+    assert.dom('textarea').hasValue('foo');
+    assert.strictEqual(this.value, 'foo');
+
+    assert.true(
+      hasDeprecationStartingWith(
+        '[AuTextarea] The `@value` argument is deprecated. Use the `value` attribute and the `{{on}}` modifier instead.',
+      ),
+    );
+  });
+
+  test('it supports the `value` attribute', async function (assert) {
+    this.value = '';
+    this.handleChange = (event) => {
+      this.set('value', event.target.value);
+    };
+
+    await render(
+      hbs`<AuTextarea value={{this.value}} {{on "change" this.handleChange}} />`,
+    );
+    assert.dom('textarea').hasNoValue();
+
+    this.set('value', 'foo');
+    assert.dom('textarea').hasValue('foo');
+
+    await fillIn('textarea', 'bar');
+    assert.strictEqual(this.value, 'bar');
+    assert.false(
+      hasDeprecationStartingWith(
+        '[AuTextarea] The `@value` argument is deprecated. Use the `value` attribute and the `{{on}}` modifier instead.',
+      ),
+    );
+  });
+
+  test('it supports updating the value through the block contents', async function (assert) {
+    this.value = '';
+    this.handleChange = (event) => {
+      this.value = event.target.value;
+    };
+
+    await render(
+      hbs`<AuTextarea {{on "change" this.handleChange}}>{{this.value}}</AuTextarea>`,
+    );
+    assert.dom('textarea').hasNoValue();
+
+    this.set('value', 'foo');
+    assert.dom('textarea').hasValue('foo');
+
+    await fillIn('textarea', 'bar');
+    assert.dom('textarea').hasValue('bar');
+    assert.strictEqual(this.value, 'bar');
+    assert.false(
+      hasDeprecationStartingWith(
+        '[AuTextarea] The `@value` argument is deprecated. Use the `value` attribute and the `{{on}}` modifier instead.',
+      ),
+    );
   });
 });


### PR DESCRIPTION
This removes the 2-way-binding setup in the `AuTextarea` component.
## Migration guide
Simply replace the `@value` argument with a value property and event handler that updates the value instead.
```diff
- <AuTextarea @value={{this.someValue}} />
+ <AuTextarea value={{this.someValue}} {{on "change" this.handleChange}} />
```

Closes #436 