### PR TITLE
Deprecate the `@size` argument for the `AuLoader` component

### DIFF
--- a/addon/components/au-loader.gjs
+++ b/addon/components/au-loader.gjs
@@ -1,7 +1,21 @@
+import { deprecate } from '@ember/debug';
 import Component from '@glimmer/component';
 
 export default class AuLoader extends Component {
   get padding() {
+    deprecate(
+      '[AuLoader] The `@size` argument is deprecated. Use `@padding` instead.',
+      !('size' in this.args),
+      {
+        id: '@appuniversum/ember-appuniversum.au-loader-size',
+        until: '3.0.0',
+        for: '@appuniversum/ember-appuniversum',
+        since: {
+          enabled: '2.17.0',
+        },
+      },
+    );
+
     if (this.args.padding == 'small') return 'au-c-loader--small';
     if (this.args.padding == 'large') return 'au-c-loader--large';
     if (this.args.size == 'small')

--- a/tests/integration/components/au-loader-test.js
+++ b/tests/integration/components/au-loader-test.js
@@ -2,16 +2,43 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { hasDeprecationStartingWith } from '../../helpers/deprecations';
 
 module('Integration | Component | au-loader', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
+  test('it renders a hidden loading text for screen readers', async function (assert) {
     await render(hbs`<AuLoader />`);
 
-    assert.dom(this.element).hasText('Aan het laden');
+    assert.dom().hasText('Aan het laden');
+  });
+
+  test('it supports rendering a custom hidden loading text', async function (assert) {
+    await render(hbs`<AuLoader @message="Loading" />`);
+
+    assert.dom().hasText('Loading');
+  });
+
+  test('it supports disabling the hidden message', async function (assert) {
+    await render(hbs`<AuLoader @disableMessage={{true}} />`);
+
+    assert.dom().hasNoText();
+  });
+
+  test('it triggers a deprecation when the `@size` argument is used', async function (assert) {
+    await render(hbs`<AuLoader @padding="small" />`);
+
+    assert.false(
+      hasDeprecationStartingWith(
+        '[AuLoader] The `@size` argument is deprecated. Use `@padding` instead.',
+      ),
+    );
+
+    await render(hbs`<AuLoader @size="small" />`);
+    assert.true(
+      hasDeprecationStartingWith(
+        '[AuLoader] The `@size` argument is deprecated. Use `@padding` instead.',
+      ),
+    );
   });
 });


### PR DESCRIPTION
We added a deprecation comment to the component without actually triggering a deprecation. I stumbled uppon this by accident when removing the other deprecations 😄. It would be nice if we could also remove this in v3.