### PR TITLE
Drop Ember 3.28 and 4.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.28
           - ember-lts-4.12
           - ember-release
           - ember-beta

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Ember addon that provides components for Flanders themed applications.
 
 ## Compatibility
 
-- Ember.js v3.28 or above
-- Ember CLI v3.28 or above
+- Ember.js v4.8 or above
+- Ember CLI v4.8 or above
 - Node.js v14 or above
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "ember-power-select": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
+    "ember-source": "^4.8.0 || ^5.0.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -7,17 +7,6 @@ module.exports = async function () {
   return {
     scenarios: [
       {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-            'ember-cli': '~3.28.0',
-            'ember-qunit': '^6.0.0',
-            '@ember/test-helpers': '^2.9.3',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.12',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Both are end-of-life. 4.8 still receives security patches until december.

https://emberjs.com/releases/lts/