### PR TITLE
Fix a FastBoot issue caused by inputmask

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "ember-template-imports": "^3.4.2",
         "ember-test-selectors": "^6.0.0",
         "ember-truth-helpers": "^3.1.1 || ^4.0.3",
-        "inputmask": "^5.0.7",
+        "inputmask": "^5.0.9-beta.45",
         "merge-anything": "^5.1.3",
         "tracked-toolbox": "^2.0.0"
       },
@@ -35751,9 +35751,9 @@
       "dev": true
     },
     "node_modules/inputmask": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.7.tgz",
-      "integrity": "sha512-rUxbRDS25KEib+c/Ow+K01oprU/+EK9t9SOPC8ov94/ftULGDqj1zOgRU/Hko6uzoKRMdwCfuhAafJ/Wk2wffQ=="
+      "version": "5.0.9-beta.45",
+      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.9-beta.45.tgz",
+      "integrity": "sha512-Nh6RHifykvEfPvnpCiwEER8LcDTAWvWKWUnVsRjqOyutGwAdjFuucCDI3YAm8tTVmhsmAydqEs+ORwllkN7Pfw=="
     },
     "node_modules/inquirer": {
       "version": "7.3.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@glimmer/util": "0.84.3",
     "ember-source": "$ember-source"
   },
-  "overridesNotes": {
+  "overridesComments": {
     "@glimmer/validator and util": "https://github.com/emberjs/ember.js/issues/20502",
     "ember-source": "storybook/ember, zestia/auto-focus and focus-trap all depend on ember-source peerDeps that don't match all our test scenarios"
   },
@@ -99,9 +99,12 @@
     "ember-template-imports": "^3.4.2",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1 || ^4.0.3",
-    "inputmask": "^5.0.7",
+    "inputmask": "^5.0.9-beta.45",
     "merge-anything": "^5.1.3",
     "tracked-toolbox": "^2.0.0"
+  },
+  "dependenciesComments": {
+    "inputmask": "switch back to the stable releases once 5.0.9+ is out. More info: https://github.com/appuniversum/ember-appuniversum/issues/462"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
The latest stable release of the inputmask library is incompatible with FastBoot. The issue has been fixed, but hasn't been released as a stable release yet. We use the beta as a temporary workaround.

Closes #462 