### PR TITLE
[Experimental feature] Add support for using components as icons

### DIFF
--- a/addon/components/au-accordion.gts
+++ b/addon/components/au-accordion.gts
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { modifier } from 'ember-modifier';
 import AuButton from './au-button';
 import AuContent from './au-content';
-import AuIcon from './au-icon';
+import AuIcon, { type AuIconSignature } from './au-icon';
 import AuLoader from './au-loader';
 import AuToolbar from './au-toolbar';
 
@@ -16,8 +16,8 @@ const autofocus = modifier(function autofocus(element: HTMLElement) {
 export interface AuAccordionSignature {
   Args: {
     buttonLabel?: string;
-    iconClosed?: string;
-    iconOpen?: string;
+    iconClosed?: AuIconSignature['Args']['icon'];
+    iconOpen?: AuIconSignature['Args']['icon'];
     isOpenInitially?: boolean;
     loading?: boolean;
     reverse?: boolean;

--- a/addon/components/au-alert.gts
+++ b/addon/components/au-alert.gts
@@ -2,12 +2,12 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import AuIcon from './au-icon';
+import AuIcon, { type AuIconSignature } from './au-icon';
 
 export interface AuAlertSignature {
   Args: {
     closable?: boolean;
-    icon?: string;
+    icon?: AuIconSignature['Args']['icon'];
     iconVisible?: boolean;
     onClose?: () => void;
     size?: 'tiny' | 'small';

--- a/addon/components/au-badge.gts
+++ b/addon/components/au-badge.gts
@@ -1,9 +1,9 @@
 import Component from '@glimmer/component';
-import AuIcon from './au-icon';
+import AuIcon, { type AuIconSignature } from './au-icon';
 
 export interface AuBadgeSignature {
   Args: {
-    icon?: string;
+    icon?: AuIconSignature['Args']['icon'];
     iconVisible?: boolean;
     number?: number;
     size?: 'small';

--- a/addon/components/au-button.gts
+++ b/addon/components/au-button.gts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import AuIcon from './au-icon';
+import AuIcon, { type AuIconSignature } from './au-icon';
 import { LoadingAnimation } from '../private/components/loading-animation';
 
 const SKINS = [
@@ -15,7 +15,7 @@ export interface AuButtonSignature {
     alert?: boolean;
     disabled?: boolean;
     hideText?: boolean;
-    icon?: string;
+    icon?: AuIconSignature['Args']['icon'];
     iconAlignment?: 'left' | 'right';
     loading?: boolean;
     loadingMessage?: string;

--- a/addon/components/au-card.gts
+++ b/addon/components/au-card.gts
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import AuBadge from './au-badge';
 import AuButton from './au-button';
 import AuContent, { type AuContentSignature } from './au-content';
-import AuIcon from './au-icon';
+import AuIcon, { type AuIconSignature } from './au-icon';
 
 export interface AuCardSignature {
   Args: {
@@ -188,7 +188,7 @@ export default class AuCard extends Component<AuCardSignature> {
 
 interface HeaderSignature {
   Args: {
-    badgeIcon?: string;
+    badgeIcon?: AuIconSignature['Args']['icon'];
     badgeNumber?: number;
     badgeSize?: 'small';
     badgeSkin?: 'border' | 'action' | 'brand' | 'success' | 'warning' | 'error';

--- a/addon/components/au-icon.gts
+++ b/addon/components/au-icon.gts
@@ -7,10 +7,10 @@ export interface AuIconSignature {
     alignment?: 'left' | 'right';
     // TODO: We should deprecate the non-boolean versions since there is no reason to support them
     ariaHidden?: boolean | 'true' | 'false';
-    icon: string | ComponentLike<Record<string, never>>;
+    icon: string | ComponentLike<{ Element: Element }>;
     size?: 'large';
   };
-  Element: SVGSVGElement;
+  Element: Element;
 }
 
 export default class AuIcon extends Component<AuIconSignature> {
@@ -47,10 +47,10 @@ export default class AuIcon extends Component<AuIconSignature> {
   <template>
     {{#if this.iconComponent}}
       {{#let this.iconComponent as |Icon|}}
-        {{! @glint-expect-error: glint doesn't like us setting attributes on the passed component }}
         <Icon
           class="au-c-icon {{this.alignment}} {{this.size}}"
           aria-hidden={{this.ariaHidden}}
+          ...attributes
         />
       {{/let}}
     {{else}}

--- a/addon/components/au-icon.gts
+++ b/addon/components/au-icon.gts
@@ -1,12 +1,13 @@
 import { getOwner } from '@ember/owner';
 import Component from '@glimmer/component';
+import { type ComponentLike } from '@glint/template';
 
 export interface AuIconSignature {
   Args: {
     alignment?: 'left' | 'right';
     // TODO: We should deprecate the non-boolean versions since there is no reason to support them
     ariaHidden?: boolean | 'true' | 'false';
-    icon: string;
+    icon: string | ComponentLike<Record<string, never>>;
     size?: 'large';
   };
   Element: SVGSVGElement;
@@ -39,16 +40,30 @@ export default class AuIcon extends Component<AuIconSignature> {
     }
   }
 
+  get iconComponent() {
+    return typeof this.args.icon !== 'string' && this.args.icon;
+  }
+
   <template>
-    <svg
-      role="img"
-      class="au-c-icon au-c-icon--{{@icon}} {{this.alignment}} {{this.size}}"
-      aria-hidden={{this.ariaHidden}}
-      ...attributes
-    >
-      <use
-        xlink:href="{{this.iconPrefix}}@appuniversum/ember-appuniversum/appuniversum-symbolset.svg#{{@icon}}"
-      ></use>
-    </svg>
+    {{#if this.iconComponent}}
+      {{#let this.iconComponent as |Icon|}}
+        {{! @glint-expect-error: glint doesn't like us setting attributes on the passed component }}
+        <Icon
+          class="au-c-icon {{this.alignment}} {{this.size}}"
+          aria-hidden={{this.ariaHidden}}
+        />
+      {{/let}}
+    {{else}}
+      <svg
+        role="img"
+        class="au-c-icon au-c-icon--{{@icon}} {{this.alignment}} {{this.size}}"
+        aria-hidden={{this.ariaHidden}}
+        ...attributes
+      >
+        <use
+          xlink:href="{{this.iconPrefix}}@appuniversum/ember-appuniversum/appuniversum-symbolset.svg#{{@icon}}"
+        ></use>
+      </svg>
+    {{/if}}
   </template>
 }

--- a/addon/components/au-input.gts
+++ b/addon/components/au-input.gts
@@ -1,11 +1,11 @@
 import Component from '@glimmer/component';
-import AuIcon from './au-icon';
+import AuIcon, { type AuIconSignature } from './au-icon';
 
 export interface AuInputSignature {
   Args: {
     disabled?: boolean;
     error?: boolean;
-    icon?: string;
+    icon?: AuIconSignature['Args']['icon'];
     iconAlignment?: 'left' | 'right';
     warning?: boolean;
     width?: 'block';

--- a/addon/components/au-link-external.gts
+++ b/addon/components/au-link-external.gts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import AuIcon from './au-icon';
+import AuIcon, { type AuIconSignature } from './au-icon';
 
 const SKIN_CLASSES = {
   primary: 'au-c-link',
@@ -12,7 +12,7 @@ const SKIN_CLASSES = {
 export interface AuLinkExternalSignature {
   Args: {
     hideText?: boolean;
-    icon?: string;
+    icon?: AuIconSignature['Args']['icon'];
     iconAlignment?: 'left' | 'right';
     skin?:
       | 'primary'

--- a/addon/components/au-link.gts
+++ b/addon/components/au-link.gts
@@ -1,6 +1,6 @@
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
-import AuIcon from './au-icon';
+import AuIcon, { type AuIconSignature } from './au-icon';
 import linkToModels from '../private/helpers/link-to-models';
 
 const SKIN_CLASSES = {
@@ -22,7 +22,7 @@ export interface AuLinkSignature {
       | 'button-naked';
     width?: 'block';
     query?: Record<string, unknown>;
-    icon?: string;
+    icon?: AuIconSignature['Args']['icon'];
     route: string;
     hideText?: boolean;
     model?: unknown;

--- a/addon/components/au-pill.gts
+++ b/addon/components/au-pill.gts
@@ -1,14 +1,14 @@
 import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
-import AuIcon from './au-icon';
+import AuIcon, { type AuIconSignature } from './au-icon';
 import linkToModels from '../private/helpers/link-to-models';
 
 const PILL_SIZES = ['small'];
 
 export interface AuPillSignature {
   Args: {
-    actionIcon?: string;
+    actionIcon?: AuIconSignature['Args']['icon'];
     actionText?: string;
     draft?: boolean;
     href?: string;
@@ -144,7 +144,7 @@ export default class AuPill extends Component<AuPillSignature> {
 
 interface InnerSignature {
   Args: {
-    icon?: string;
+    icon?: AuIconSignature['Args']['icon'];
     iconAlignment?: 'left' | 'right';
     hideText?: boolean;
   };


### PR DESCRIPTION
> [!WARNING]  
> This setup is still in an experimental state. We want to try it out in a couple of specific places before considering this ready to use by all the Appuniversum users. We might still break the setup in future minor versions until we announce it as stable.

<hr>

Another PR in the [line](#424) of [PRs](#430) attempting to address the issue of inline SVGs.

This time the approach is to allow passing of arbitrary components to `AuIcon` (and by extension, any component taking an `@icon` argument).

The advantages of this method are that this is very flexible to the user. Also, by overloading `@icon` it avoids confusion that could be caused by adding a new argument, as only one of `string` or `Component` can be passed.

A minor downside is that the user can potentially pass a component that could cause rendering issues.

A risk is that in order to pass arguments to the component, for example; to pass an `AuIcon` as a custom component, you need an argument to specify which icon to use; you must use the `component` helper. In this way it is easy to write code that embroider can't statically analyse.