### PR TITLE
docs: add link to Getting started in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ npm install --save-dev @appuniversum/ember-appuniversum
 
 This ember addon wraps a CSS framework for Flanders government applications called Appuniversum. It provides components that helps being compliant with this framework in Ember apps.
 
+To get started using this addon in your Ember.js app, follow the [Getting started](https://appuniversum.github.io/ember-appuniversum/?path=/story/outline-getting-started--page) guide.
+
 ## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.


### PR DESCRIPTION
Adding this addon to a new Ember app has some prerequisites that are nicely explained in the **Getting started** section of the Storybook, but they're not mentioned/linked to in the README.
This PR adds a link in the README so it's easier to find out how to add the addon.