### PR TITLE
Fix a styling issue in the `AuMainHeader` component

### DIFF
--- a/styles/components/_c-main-header.scss
+++ b/styles/components/_c-main-header.scss
@@ -19,7 +19,7 @@ $au-main-header-divider-rotation: -19deg !default;
 
 .au-c-main-header {
   position: relative;
-  z-index: var(--au-z-index-alpha);
+  z-index: var(--au-z-index-beta);
   display: flex;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
There are some elements that are also using the alpha z-index, which causes issues if elements inside the main header escape its boundaries (for example dropdowns, or drop shadows). By setting it to the beta value, things should work as expected.

Closes #386 