### PR TITLE
Accessibility update / Tested for frontend-subsidiepunt

### DIFF
--- a/addon/components/au-main-header.gts
+++ b/addon/components/au-main-header.gts
@@ -62,7 +62,7 @@ export default class AuMainHeader extends Component<AuMainHeaderSignature> {
         </a>
       </div>
       <nav
-        aria-label="{{this.navigationAriaLabel}}"
+        aria-label={{this.navigationAriaLabel}}
         class="au-c-main-header__actions"
       >
         <ul class="au-c-list-horizontal">

--- a/addon/components/au-main-header.gts
+++ b/addon/components/au-main-header.gts
@@ -13,6 +13,7 @@ export interface AuMainHeaderSignature {
     appTitle: string;
     brandLink?: string;
     contactRoute?: string;
+    contactLabel?: string;
     homeRoute?: string;
   };
   Blocks: {
@@ -22,6 +23,11 @@ export interface AuMainHeaderSignature {
 }
 
 export default class AuMainHeader extends Component<AuMainHeaderSignature> {
+  get contactLabel() {
+    if (this.args.contactLabel) return this.args.contactLabel;
+    else return 'Contacteer ons';
+  }
+
   @action
   headerLinkFocus() {
     document.querySelector<HTMLElement>('#main')?.focus();
@@ -58,7 +64,7 @@ export default class AuMainHeader extends Component<AuMainHeaderSignature> {
                 @skin="secondary"
                 @icon={{QuestionCircleIcon}}
               >
-                Contacteer ons
+                {{@contactLabel}}
               </AuLink>
             </li>
           {{/if}}

--- a/addon/components/au-main-header.gts
+++ b/addon/components/au-main-header.gts
@@ -55,7 +55,7 @@ export default class AuMainHeader extends Component<AuMainHeaderSignature> {
           Naar de hoofdinhoud
         </a>
       </div>
-      <nav class="au-c-main-header__actions">
+      <nav aria-label="Informatie en instellingen" class="au-c-main-header__actions">
         <ul class="au-c-list-horizontal">
           {{#if @contactRoute}}
             <li class="au-c-list-horizontal__item">

--- a/addon/components/au-main-header.gts
+++ b/addon/components/au-main-header.gts
@@ -15,6 +15,7 @@ export interface AuMainHeaderSignature {
     contactRoute?: string;
     contactLabel?: string;
     homeRoute?: string;
+    navigationAriaLabel?: string;
   };
   Blocks: {
     default: [];
@@ -26,6 +27,11 @@ export default class AuMainHeader extends Component<AuMainHeaderSignature> {
   get contactLabel() {
     if (this.args.contactLabel) return this.args.contactLabel;
     else return 'Contacteer ons';
+  }
+
+  get navigationAriaLabel() {
+    if (this.args.navigationAriaLabel) return this.args.navigationAriaLabel;
+    else return 'Informatie en instellingen';
   }
 
   @action
@@ -56,7 +62,7 @@ export default class AuMainHeader extends Component<AuMainHeaderSignature> {
         </a>
       </div>
       <nav
-        aria-label="Informatie en instellingen"
+        aria-label="{{this.navigationAriaLabel}}"
         class="au-c-main-header__actions"
       >
         <ul class="au-c-list-horizontal">

--- a/addon/components/au-main-header.gts
+++ b/addon/components/au-main-header.gts
@@ -64,7 +64,7 @@ export default class AuMainHeader extends Component<AuMainHeaderSignature> {
                 @skin="secondary"
                 @icon={{QuestionCircleIcon}}
               >
-                {{@contactLabel}}
+                {{this.contactLabel}}
               </AuLink>
             </li>
           {{/if}}

--- a/addon/components/au-main-header.gts
+++ b/addon/components/au-main-header.gts
@@ -55,7 +55,10 @@ export default class AuMainHeader extends Component<AuMainHeaderSignature> {
           Naar de hoofdinhoud
         </a>
       </div>
-      <nav aria-label="Informatie en instellingen" class="au-c-main-header__actions">
+      <nav
+        aria-label="Informatie en instellingen"
+        class="au-c-main-header__actions"
+      >
         <ul class="au-c-list-horizontal">
           {{#if @contactRoute}}
             <li class="au-c-list-horizontal__item">
@@ -85,11 +88,7 @@ class NavigationNarrator extends Component {
   }
 
   <template>
-    <div
-      aria-live="assertive"
-      aria-atomic="true"
-      aria-relevant="all"
-    >
+    <div aria-live="assertive" aria-atomic="true" aria-relevant="all">
       <span class="au-u-hidden-visually">
         {{this.activeRoute}}
       </span>

--- a/addon/components/au-main-header.gts
+++ b/addon/components/au-main-header.gts
@@ -81,7 +81,6 @@ class NavigationNarrator extends Component {
   <template>
     <div
       aria-live="assertive"
-      aria-controls="main"
       aria-atomic="true"
       aria-relevant="all"
     >

--- a/stories/5-components/Brand/AuMainHeader.stories.js
+++ b/stories/5-components/Brand/AuMainHeader.stories.js
@@ -15,7 +15,8 @@ export default {
     },
     contactLabel: {
       control: 'text',
-      description: 'Set the label for the contact link (default: Contacteer ons)',
+      description:
+        'Set the label for the contact link (default: Contacteer ons)',
     },
   },
   parameters: {

--- a/stories/5-components/Brand/AuMainHeader.stories.js
+++ b/stories/5-components/Brand/AuMainHeader.stories.js
@@ -13,6 +13,10 @@ export default {
       control: 'text',
       description: 'Pass a route for the contact link',
     },
+    contactLabel: {
+      control: 'text',
+      description: 'Set the label for the contact link (default: Contacteer ons)',
+    },
   },
   parameters: {
     layout: 'padded',
@@ -26,6 +30,7 @@ const Template = (args) => ({
       @appTitle={{this.appTitle}}
       @homeRoute={{this.homeRoute}}
       @contactRoute={{this.contactRoute}}
+      @contactLabel={{this.contactLabel}}
     >
       <AuDropdown @title="Demo dropdown" @alignment="right" role="menu">
         <AuButton @skin="link" @icon="logout" role="menuitem">
@@ -42,4 +47,5 @@ Component.args = {
   appTitle: 'App title',
   homeRoute: 'home',
   contactRoute: 'contact',
+  contactLabel: 'Contacteer ons',
 };

--- a/stories/5-components/Brand/AuMainHeader.stories.js
+++ b/stories/5-components/Brand/AuMainHeader.stories.js
@@ -18,6 +18,11 @@ export default {
       description:
         'Set the label for the contact link (default: Contacteer ons)',
     },
+    navigationAriaLabel: {
+      control: 'text',
+      description:
+        'Set the aria-label for the navigation (default: Informatie en instellingen)',
+    },
   },
   parameters: {
     layout: 'padded',
@@ -32,6 +37,7 @@ const Template = (args) => ({
       @homeRoute={{this.homeRoute}}
       @contactRoute={{this.contactRoute}}
       @contactLabel={{this.contactLabel}}
+      @navigationAriaLabel={{this.navigationAriaLabel}}
     >
       <AuDropdown @title="Demo dropdown" @alignment="right" role="menu">
         <AuButton @skin="link" @icon="logout" role="menuitem">
@@ -49,4 +55,5 @@ Component.args = {
   homeRoute: 'home',
   contactRoute: 'contact',
   contactLabel: 'Contacteer ons',
+  navigationAriaLabel: 'Informatie en instellingen',
 };

--- a/stories/5-components/Navigation/AuDropdown.stories.js
+++ b/stories/5-components/Navigation/AuDropdown.stories.js
@@ -47,6 +47,7 @@ export default {
 
 const Template = (args) => ({
   template: hbs`
+    {{! template-lint-disable require-context-role }}
     <AuDropdown
       @title={{this.title}}
       @alignment={{this.alignment}}
@@ -64,12 +65,15 @@ const Template = (args) => ({
       <AuButton @skin="link" @icon="logout" role="menuitem">
         Afmelden
       </AuButton>
-    </AuDropdown>`,
+    </AuDropdown>
+    {{! template-lint-enable require-context-role }}
+  `,
   context: args,
 });
 
 const TemplateSeparator = (args) => ({
   template: hbs`
+    {{! template-lint-disable require-context-role }}
     <AuDropdown
       @title={{this.title}}
       @alignment={{this.alignment}}
@@ -101,9 +105,12 @@ const TemplateSeparator = (args) => ({
       <AuButton @alert="true" @skin="link" @icon="bin" role="menuitem">
         Verwijder
       </AuButton>
-    </AuDropdown>`,
+    </AuDropdown>
+    {{! template-lint-enable require-context-role }}
+  `,
   context: args,
 });
+/* prettier-ignore-end */
 
 export const Component = Template.bind({});
 Component.args = {

--- a/stories/5-components/Navigation/AuDropdown.stories.js
+++ b/stories/5-components/Navigation/AuDropdown.stories.js
@@ -57,7 +57,6 @@ const Template = (args) => ({
       @hideText={{this.hideText}}
       @alert={{this.alert}}
       @onClose={{this.onClose}}
-      role="menu"
     >
       <AuButton @skin="link" @icon="switch" role="menuitem">
         Switch profile
@@ -81,7 +80,6 @@ const TemplateSeparator = (args) => ({
       @hideText={{this.hideText}}
       @alert={{this.alert}}
       @onClose={{this.onClose}}
-      role="menu"
     >
       <AuButton @skin="link" role="menuitem">
         Agendapunt toevoegen

--- a/styles/components/_c-data-table.scss
+++ b/styles/components/_c-data-table.scss
@@ -191,7 +191,7 @@
   position: relative;
   text-decoration: underline;
   text-decoration-color: var(--au-gray-300);
-  color: var(--au-gray-600);
+  color: var(--au-gray-700);
   transition: color var(--au-transition);
 
   &:hover {

--- a/styles/components/_c-help-text.scss
+++ b/styles/components/_c-help-text.scss
@@ -6,8 +6,8 @@
    ========================================================================== */
 
 $au-help-text-color: var(--au-gray-900) !default;
-$au-help-text-secondary-color: var(--au-gray-600) !default;
-$au-help-text-tertiary-color: var(--au-gray-600) !default;
+$au-help-text-secondary-color: var(--au-gray-700) !default;
+$au-help-text-tertiary-color: var(--au-gray-700) !default;
 $au-help-text-warning-color: var(--au-orange-700) !default;
 $au-help-text-error-color: var(--au-red-700) !default;
 $au-help-text-font-size: var(--au-small) !default;


### PR DESCRIPTION
Accessibility fixes:
- Fix AuDataTable sortable header color contrast
- Fix secondary helptext color contrast
- Remove aria-controls from aria-live region: not a valid property

Documentation update:
- fix dropdown example: role=menu should not be on the dropdown button

Additions:
- AuMainHeader: add override on the contact link text. Certain products apply a hack to put a different link which breaks the semantics of this component