### PR TITLE
Update to inputmask v5.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "ember-template-imports": "^4.1.1",
         "ember-test-selectors": "^6.0.0",
         "ember-truth-helpers": "^3.1.1 || ^4.0.3",
-        "inputmask": "^5.0.9-beta.45",
+        "inputmask": "^5.0.9",
         "merge-anything": "^5.1.3",
         "tracked-toolbox": "^2.0.0"
       },
@@ -33633,9 +33633,9 @@
       "dev": true
     },
     "node_modules/inputmask": {
-      "version": "5.0.9-beta.45",
-      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.9-beta.45.tgz",
-      "integrity": "sha512-Nh6RHifykvEfPvnpCiwEER8LcDTAWvWKWUnVsRjqOyutGwAdjFuucCDI3YAm8tTVmhsmAydqEs+ORwllkN7Pfw=="
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.9.tgz",
+      "integrity": "sha512-s0lUfqcEbel+EQXtehXqwCJGShutgieOaIImFKC/r4reYNvX3foyrChl6LOEvaEgxEbesePIrw1Zi2jhZaDZbQ=="
     },
     "node_modules/inquirer": {
       "version": "7.3.3",

--- a/package.json
+++ b/package.json
@@ -98,12 +98,9 @@
     "ember-template-imports": "^4.1.1",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1 || ^4.0.3",
-    "inputmask": "^5.0.9-beta.45",
+    "inputmask": "^5.0.9",
     "merge-anything": "^5.1.3",
     "tracked-toolbox": "^2.0.0"
-  },
-  "dependenciesComments": {
-    "inputmask": "switch back to the stable releases once 5.0.9+ is out. More info: https://github.com/appuniversum/ember-appuniversum/issues/462"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
The change we needed was released so we no longer need the beta version.