### PR TITLE
Update to TypeScript 5.6.3

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,45 +1,8 @@
-/**
- * Debugging:
- *   https://eslint.org/docs/latest/use/configure/debug
- *  ----------------------------------------------------
- *
- *   Print a file's calculated configuration
- *
- *     npx eslint --print-config path/to/file.js
- *
- *   Inspecting the config
- *
- *     npx eslint --inspect-config
- *
- */
-
-import globals from 'globals';
-import js from '@eslint/js';
-
 import ts from 'typescript-eslint';
-
 import ember from 'eslint-plugin-ember/recommended';
-
-import qunit from 'eslint-plugin-qunit';
-import n from 'eslint-plugin-n';
-
-import babelParser from '@babel/eslint-parser';
 
 const parserOptions = {
   esm: {
-    js: {
-      ecmaFeatures: { modules: true },
-      ecmaVersion: 'latest',
-      requireConfigFile: false,
-      babelOptions: {
-        plugins: [
-          [
-            '@babel/plugin-proposal-decorators',
-            { decoratorsBeforeExport: true },
-          ],
-        ],
-      },
-    },
     ts: {
       projectService: true,
       tsconfigRootDir: import.meta.dirname,
@@ -48,117 +11,28 @@ const parserOptions = {
 };
 
 export default ts.config(
-  js.configs.recommended,
-  ember.configs.base,
-  ember.configs.gjs,
-  ember.configs.gts,
-  /**
-   * Ignores must be in their own object
-   * https://eslint.org/docs/latest/use/configure/ignore
-   */
   {
-    ignores: [
-      'declarations/',
-      'dist/',
-      '.node_modules.ember-try/',
-      'coverage/',
-      'storybook-static/',
-    ],
-  },
-  /**
-   * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options
-   */
-  {
-    linterOptions: {
-      reportUnusedDisableDirectives: 'error',
-    },
+    ignores: ['**/*.js', '**/*.mjs'],
   },
   {
-    files: ['**/*.js'],
-    languageOptions: {
-      parser: babelParser,
-    },
-  },
-  {
-    files: ['**/*.{js,gjs}'],
-    languageOptions: {
-      parserOptions: parserOptions.esm.js,
-      globals: {
-        ...globals.browser,
-      },
-    },
-  },
-  {
+    name: 'ts',
     files: ['**/*.ts'],
     languageOptions: {
+      // Uncommenting this fixes the issue so it seems to be related to switching parsers for different kinds of typed files?
+      // parser: ember.parser,
       parserOptions: parserOptions.esm.ts,
     },
-    extends: [ember.configs.base, ...ts.configs.recommendedTypeChecked],
+    extends: [...ts.configs.recommendedTypeChecked],
+    // extends: [...ts.configs.recommended], // also fails
   },
   {
+    name: 'gts',
     files: ['**/*.gts'],
     languageOptions: {
       parser: ember.parser,
       parserOptions: parserOptions.esm.ts,
     },
-    extends: [...ts.configs.recommendedTypeChecked, ember.configs.gts],
-    rules: {
-      // This works around an issue in Glint https://github.com/typed-ember/glint/issues/697
-      // It also makes adding state to a component easier, since no other code changes would be needed.
-      'ember/no-empty-glimmer-component-classes': 'off',
-    },
-  },
-  {
-    files: ['tests/**/*-test.{js,gjs,ts,gts}'],
-    plugins: {
-      qunit,
-    },
-  },
-  /**
-   * CJS node files
-   */
-  {
-    files: [
-      'index.js',
-      '**/*.cjs',
-      'config/**/*.js',
-      'testem.js',
-      'testem*.js',
-      '.prettierrc.js',
-      '.stylelintrc.js',
-      '.template-lintrc.js',
-      'ember-cli-build.js',
-      'tests/dummy/config/**/*.js',
-      '.storybook/main.js',
-    ],
-    plugins: {
-      n,
-    },
-
-    languageOptions: {
-      sourceType: 'script',
-      ecmaVersion: 'latest',
-      globals: {
-        ...globals.node,
-      },
-    },
-  },
-  /**
-   * ESM node files
-   */
-  {
-    files: ['**/*.mjs'],
-    plugins: {
-      n,
-    },
-
-    languageOptions: {
-      sourceType: 'module',
-      ecmaVersion: 'latest',
-      parserOptions: parserOptions.esm.js,
-      globals: {
-        ...globals.node,
-      },
-    },
+    // These don't really matter, commented or not, it fails
+    // extends: [...ts.configs.recommendedTypeChecked, ember.configs.gts],
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "stylelint-prettier": "^4.1.0",
         "svg-symbols": "^1.0.5",
         "tracked-built-ins": "^3.3.0",
-        "typescript": "~5.5.0",
+        "typescript": "~5.6.3",
         "typescript-eslint": "^8.13.0",
         "webpack": "^5.95.0"
       },
@@ -45184,9 +45184,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "stylelint-prettier": "^4.1.0",
     "svg-symbols": "^1.0.5",
     "tracked-built-ins": "^3.3.0",
-    "typescript": "~5.5.0",
+    "typescript": "~5.6.3",
     "typescript-eslint": "^8.13.0",
     "webpack": "^5.95.0"
   },


### PR DESCRIPTION
Minimal reproduction of an eslint issue when updating to TypeScript 5.6.3.

Current config that breaks:
```js
import ts from 'typescript-eslint';
import ember from 'eslint-plugin-ember/recommended';

const parserOptions = {
  esm: {
    ts: {
      projectService: true,
      tsconfigRootDir: import.meta.dirname,
    },
  },
};

export default ts.config(
  {
    ignores: ['**/*.js', '**/*.mjs'],
  },
  {
    name: 'ts',
    files: ['**/*.ts'],
    languageOptions: {
      // Uncommenting this fixes the issue so it seems to be related to switching parsers for different kinds of typed files?
      // parser: ember.parser,
      parserOptions: parserOptions.esm.ts,
    },
    extends: [...ts.configs.recommendedTypeChecked],
    // extends: [...ts.configs.recommended], // also fails
  },
  {
    name: 'gts',
    files: ['**/*.gts'],
    languageOptions: {
      parser: ember.parser,
      parserOptions: parserOptions.esm.ts,
    },
    // These don't really matter, commented or not, it fails
    // extends: [...ts.configs.recommendedTypeChecked, ember.configs.gts],
  },
);
```