### PR TITLE
Add support for ember-source v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
         "ember-power-select": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x || 8.x"
       },
       "peerDependencies": {
-        "ember-source": "^4.12.0 || ^5.0.0",
+        "ember-source": "^4.12.0 || ^5.0.0 || ^6.0.0",
         "tracked-built-ins": "^3.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "ember-power-select": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x || 8.x"
   },
   "peerDependencies": {
-    "ember-source": "^4.12.0 || ^5.0.0",
+    "ember-source": "^4.12.0 || ^5.0.0 || ^6.0.0",
     "tracked-built-ins": "^3.3.0"
   },
   "engines": {


### PR DESCRIPTION
Our "release" scenario is already testing ember-source v6, and it's green so we can officially widen our peerDep range.