### PR TITLE
Feature/min size file upload

### DIFF
--- a/addon/components/au-file-upload.gts
+++ b/addon/components/au-file-upload.gts
@@ -20,6 +20,7 @@ export interface AuFileUploadSignature {
     helpTextDragDrop?: string;
     helpTextFileNotSupported?: string;
     maxFileSizeMB?: number;
+    minFileSizeMB?: number;
     multiple?: boolean;
     onFinishUpload?: (uploadedFile: number, queueInfo: QueueInfo) => void;
     onQueueUpdate?: (queueInfo: QueueInfo) => void;
@@ -87,6 +88,10 @@ export default class AuFileUpload extends Component<AuFileUploadSignature> {
     return this.args.maxFileSizeMB || 20;
   }
 
+  get minFileSizeMB() {
+    return this.args.minFileSizeMB || 0;
+  }
+
   get hasErrors() {
     return this.uploadErrorData.length > 0;
   }
@@ -138,8 +143,12 @@ export default class AuFileUpload extends Component<AuFileUploadSignature> {
       }
     }
 
-    if (!isValidFileSize(file.size, this.maxFileSizeMB)) {
-      this.addError(file, `Bestand is te groot (max ${this.maxFileSizeMB} MB)`);
+    if (!isValidFileSize(file.size, this.minFileSizeMB, this.maxFileSizeMB)) {
+      if (file.size < this.minFileSizeMB * Math.pow(1024, 2)) {
+        this.addError(file, `Bestand is te klein (min ${this.minFileSizeMB} MB)`);
+      } else {
+        this.addError(file, `Bestand is te groot (max ${this.maxFileSizeMB} MB)`);
+      }
       return false;
     }
 
@@ -302,6 +311,6 @@ function isValidExtension(
   return validExtensions.includes(extension);
 }
 
-function isValidFileSize(fileSize: number, maximumSize: number): boolean {
-  return fileSize < maximumSize * Math.pow(1024, 2);
+function isValidFileSize(fileSize: number, minimumSize: number, maximumSize: number): boolean {
+  return fileSize >= minimumSize * Math.pow(1024, 2) && fileSize < maximumSize * Math.pow(1024, 2);
 }

--- a/stories/5-components/Forms/AuFileUpload.stories.js
+++ b/stories/5-components/Forms/AuFileUpload.stories.js
@@ -25,6 +25,10 @@ export default {
       control: 'number',
       description: 'Maximum filesize allowed (in MB)',
     },
+    minFileSizeMB: {
+      control: 'number',
+      description: 'Minimum filesize allowed (in MB)',
+    },
     multiple: {
       control: 'boolean',
       description: 'Whether multiple files can be selected when uploading',
@@ -52,6 +56,7 @@ const Template = (args) => ({
       @helpTextDragDrop={{this.helpTextDragDrop}}
       @helpTextFileNotSupported={{this.helpTextFileNotSupported}}
       @maxFileSizeMB={{this.maxFileSizeMB}}
+      @minFileSizeMB={{this.minFileSizeMB}}
       @multiple={{this.multiple}}
       @onFinishUpload={{this.onFinishUpload}}
       @onQueueUpdate={{this.onQueueUpdate}}
@@ -67,6 +72,7 @@ Component.args = {
   helpTextDragDrop: 'Sleep de bestanden naar hier om toe te voegen',
   helpTextFileNotSupported: 'Dit bestandsformaat wordt niet ondersteund.',
   maxFileSizeMB: 20,
+  minFileSizeMB: 0,
   multiple: false,
   onFinishUpload: null,
   onQueueUpdate: null,


### PR DESCRIPTION
## ID
DL-6240

## Description
Currently it is possible to upload files that are 0 bytes. This does not seem very logical. We want to have an option to define a minimum file size and show an error if the file size is lower then that. 

Discussion:
- Do we want to instead make it "minFileSizeKB" and not be consistent with maxFile?
- Do we just create a option that says, "notEmpty" and put the default to 1kb? 


## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup
No special setup requirements

## How to test
Set the minFileSizeMB to "0.01" (10kb). Try to upload an empty file, you should see the error message. While 