### PR TITLE
Deprecate the internal `AuContent` usage

### DIFF
--- a/addon/components/au-accordion.gts
+++ b/addon/components/au-accordion.gts
@@ -4,12 +4,12 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { modifier } from 'ember-modifier';
 import AuButton from './au-button';
-import AuContent from './au-content';
 import AuIcon, { type AuIconSignature } from './au-icon';
 import AuLoader from './au-loader';
 import AuToolbar from './au-toolbar';
 import { NavDownIcon } from './icons/nav-down';
 import { NavRightIcon } from './icons/nav-right';
+import { MaybeAuContent } from '../private/components/maybe-au-content';
 
 const autofocus = modifier(function autofocus(element: HTMLElement) {
   element.focus();
@@ -25,6 +25,8 @@ export interface AuAccordionSignature {
     reverse?: boolean;
     skin?: 'border';
     subtitle?: string;
+    // TODO: remove in v4
+    disableAuContent?: boolean;
   };
   Blocks: {
     default: [];
@@ -112,13 +114,18 @@ export default class AuAccordion extends Component<AuAccordionSignature> {
         </Group>
       </AuToolbar>
       {{#if this.isOpen}}
-        <AuContent tabindex="0" data-test-accordion-content {{autofocus}}>
+        <MaybeAuContent
+          @useAuContent={{if @disableAuContent false true}}
+          tabindex="0"
+          data-test-accordion-content
+          {{autofocus}}
+        >
           {{#if this.loading}}
             <AuLoader data-test-accordion-loader />
           {{else}}
             {{yield}}
           {{/if}}
-        </AuContent>
+        </MaybeAuContent>
       {{/if}}
     </div>
   </template>

--- a/addon/components/au-card.gts
+++ b/addon/components/au-card.gts
@@ -3,9 +3,13 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import type { WithBoundArgs } from '@glint/template';
 import AuBadge from './au-badge';
 import AuButton from './au-button';
-import AuContent, { type AuContentSignature } from './au-content';
+import {
+  MaybeAuContent,
+  type MaybeAuContentSignature,
+} from '../private/components/maybe-au-content';
 import AuIcon, { type AuIconSignature } from './au-icon';
 import { AddIcon } from './icons/add';
 import { NavDownIcon } from './icons/nav-down';
@@ -25,13 +29,15 @@ export interface AuCardSignature {
     shadow?: boolean;
     standOut?: boolean;
     textCenter?: boolean;
+    // TODO: remove in v4
+    disableAuContent?: boolean;
   };
   Blocks: {
     default: [
       {
         header?: typeof Header;
-        content?: typeof Content;
-        footer?: typeof Footer;
+        content?: WithBoundArgs<typeof Content, 'disableAuContent'>;
+        footer?: WithBoundArgs<typeof Footer, 'disableAuContent'>;
       },
     ];
   };
@@ -194,10 +200,14 @@ export default class AuCard extends Component<AuCardSignature> {
         {{/if}}
       {{else}}
         {{yield (hash header=Header)}}
-        {{yield (hash content=Content)}}
+        {{yield
+          (hash content=(component Content disableAuContent=@disableAuContent))
+        }}
       {{/if}}
 
-      {{yield (hash footer=Footer)}}
+      {{yield
+        (hash footer=(component Footer disableAuContent=@disableAuContent))
+      }}
     </article>
   </template>
 }
@@ -257,35 +267,49 @@ class Header extends Component<HeaderSignature> {
 }
 
 interface ContentSignature {
+  Args: {
+    disableAuContent?: boolean;
+  };
   Blocks: {
     default: [];
   };
-  Element: AuContentSignature['Element'];
+  Element: MaybeAuContentSignature['Element'];
 }
 
 class Content extends Component<ContentSignature> {
   <template>
     {{#if (has-block)}}
-      <AuContent class="au-c-card__content" ...attributes>
+      <MaybeAuContent
+        @useAuContent={{if @disableAuContent false true}}
+        class="au-c-card__content"
+        ...attributes
+      >
         {{yield}}
-      </AuContent>
+      </MaybeAuContent>
     {{/if}}
   </template>
 }
 
 interface FooterSignature {
+  Args: {
+    disableAuContent?: boolean;
+  };
   Blocks: {
     default: [];
   };
-  Element: AuContentSignature['Element'];
+  Element: MaybeAuContentSignature['Element'];
 }
 
 class Footer extends Component<FooterSignature> {
   <template>
     {{#if (has-block)}}
-      <AuContent class="au-c-card__footer" ...attributes>
+      <MaybeAuContent
+        @useAuContent={{if @disableAuContent false true}}
+        class="au-c-card__footer"
+        ...attributes
+      >
         {{yield}}
-      </AuContent>
+      </MaybeAuContent>
     {{/if}}
   </template>
 }

--- a/addon/private/components/maybe-au-content.gts
+++ b/addon/private/components/maybe-au-content.gts
@@ -1,0 +1,57 @@
+import Component from '@glimmer/component';
+import AuContent, {
+  type AuContentSignature,
+} from '../../components/au-content';
+import { deprecate } from '@ember/debug';
+import { getOwnConfig } from '@embroider/macros';
+
+export interface MaybeAuContentSignature {
+  Args: {
+    useAuContent: boolean;
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: AuContentSignature['Element'];
+}
+
+const deprecationMessage = `The internal usage of the <AuContent> component is deprecated.
+
+More information can be found in the migration guide: https://github.com/appuniversum/ember-appuniversum/pull/535
+`;
+
+export class MaybeAuContent extends Component<MaybeAuContentSignature> {
+  constructor(owner: unknown, args: MaybeAuContentSignature['Args']) {
+    super(owner, args);
+
+    deprecate(deprecationMessage, !this.useAuContent, {
+      id: '@appuniversum/ember-appuniversum.internal-au-content-usage',
+      until: '4.0.0',
+      for: '@appuniversum/ember-appuniversum',
+      since: {
+        available: '3.11.0',
+        enabled: '3.11.0',
+      },
+    });
+  }
+
+  get useAuContent() {
+    const disabledGlobally = getOwnConfig<{
+      disableInternalAuContentUsage?: boolean;
+    }>()?.disableInternalAuContentUsage;
+
+    if (typeof disabledGlobally === 'undefined') {
+      return this.args.useAuContent ?? true;
+    } else {
+      return !disabledGlobally;
+    }
+  }
+
+  <template>
+    {{~#if this.useAuContent~}}
+      <AuContent ...attributes>{{yield}}</AuContent>
+    {{~else~}}
+      <div ...attributes>{{yield}}</div>
+    {{~/if~}}
+  </template>
+}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,18 +6,11 @@ module.exports = function (defaults) {
   const app = new EmberAddon(defaults, {
     'ember-cli-babel': { enableTypeScriptTransform: true },
     sassOptions: {
-      sourceMapEmbed: true,
       includePaths: ['./styles'], // This ensures that the /styles folder is watched and auto-reloading works.
     },
-    autoprefixer: {
-      enabled: true,
-      cascade: true,
-      sourcemap: true,
-    },
-    autoImport: {
-      alias: {
-        '@duetds/date-picker/loader':
-          '@duetds/date-picker/dist/loader/index.cjs',
+    '@embroider/macros': {
+      setOwnConfig: {
+        disableInternalAuContentUsage: true,
       },
     },
     fingerprint: {


### PR DESCRIPTION
Both the `<AuCard>` and `<AuAccordion>` component use the `<AuContent>` component to add styles to any content the consumer might provide.

This works fine if consumers provide simple html content, but once other components are nested, there are potential styling conflicts.

Instead of embedding the `<AuContent>` consumers should now add the `<AuContent>` component if they need it.

Closes #534

## Migration guide
### `<AuCard>`

The `<AuCard>` component uses the `<AuContent>` component for its content and footer blocks. If your nest content that depends on the generic styles you need to explicitly add the `<AuContent>` component.

```hbs
{{! Before }}
<AuCard as |card|>
  <card.content>
     <p>Some html content</p>
  </card.content>
  <card.footer>
     <p>Some html content</p>
  </card.footer>
</AuCard>

{{! After }}
<AuCard as |card|>
  <card.content>
     <AuContent>
       <p>Some html content</p>
     </AuContent>
  </card.content>
  <card.footer>
    <AuContent>
      <p>Some html content</p>
    </AuContent>
  </card.footer>
</AuCard>
```

>[!NOTE]  
>You don't need to add the `<AuContent>` wrapper if you only nest other components instead of plain HTML.

### `<AuAccordion>`
The `<AuAccordion>` uses the `<AuContent>` component for its default block content.

```hbs
{{! before }}
<AuAccordion>
  <p>Some html content</p>
</AuAccordion>

{{! after }}
<AuAccordion>
  <AuContent>
    <p>Some html content</p>
  </AuContent>
</AuAccordion>
```

>[!NOTE]  
>You don't need to add the `<AuContent>` wrapper if you only nest other components instead of plain HTML.

### Resolving the deprecation

Adding the `<AuContent>` wrappers where needed doesn't actually resolve the deprecation. There are two options for that.
#### App wide config

It's possible to add a build time flag which disables the `<AuContent>` usage in the Appuniversum components and resolves the deprecations app wide.

This is the recommended migration path since it doesn't require setting a component argument that needs to be removed in the next version. It also allows you to brute force the change in addons as well.

```js
// ember-cli-build.js
const app = new EmberApp(defaults, {
  '@embroider/macros': {
    setConfig: {
      '@appuniversum/ember-appuniversum': {
        disableInternalAuContentUsage: true,
      },
    },
  },
});
```
>[!NOTE] 
> You may need to have `@embroider/macros`  installed for this to work.

#### Component specific

You can also disable the `<AuContent>` usage for specific `<AuCard>` or `<AuAccordion>` component instances by setting the `@disableAuContent` argument to `true`. This allows more fine-grained control in case switching the whole app at once is too time consuming.

```hbs
<AuCard @disableAuContent={{true}} as |card|>
  <card.content>
     <AuContent>
       <p>Some html content</p>
     </AuContent>
  </card.content>
  <card.footer>
    <AuContent>
      <p>Some html content</p>
    </AuContent>
  </card.footer>
</AuCard>

<AuAccordion @disableAuContent={{true}}>
  <AuContent>
    <p>Some html content</p>
  </AuContent>
</AuAccordion>
```

>[!NOTE] 
> The global config is prioritized so you can't _enable_ the inner `<AuContent>` component for a specific instance again by setting  `@disableAuContent={{false}}` when the global config is also set (and when it isn't, setting to false is a noop).