### PR TITLE
Add a new `@onUpload` action to the `AuFileUpload` component

### DIFF
--- a/addon/components/au-file-upload.gts
+++ b/addon/components/au-file-upload.gts
@@ -23,6 +23,7 @@ export interface AuFileUploadSignature {
     minFileSizeKB?: number;
     multiple?: boolean;
     onFinishUpload?: (uploadedFile: number, queueInfo: QueueInfo) => void;
+    onUpload?: (data: { fileId: unknown; file: UploadFile }) => void;
     onQueueUpdate?: (queueInfo: QueueInfo) => void;
     title?: string;
   };
@@ -103,12 +104,17 @@ export default class AuFileUpload extends Component<AuFileUploadSignature> {
 
   uploadTask = task(async (file: UploadFile) => {
     this.resetErrors();
-    const uploadedFile = await this.uploadFileTask.perform(file);
+    const uploadedFileId = await this.uploadFileTask.perform(file);
 
     this.notifyQueueUpdate();
 
-    if (uploadedFile && this.args.onFinishUpload)
-      this.args.onFinishUpload(uploadedFile, this.calculateQueueInfo());
+    if (uploadedFileId) {
+      this.args.onFinishUpload?.(uploadedFileId, this.calculateQueueInfo());
+      this.args.onUpload?.({
+        fileId: uploadedFileId,
+        file,
+      });
+    }
   });
 
   uploadFileTask = task(


### PR DESCRIPTION
This is very similar to the `@onFinishUpload` action but with a more flexible signature that allows us to easily add new data in the future.

`@onUpload` also receives the `File` instance which allows consumers to display information about the selected file without having to fetch the corresponding data from the database first.

No tests since we don't have a request mocking setup yet and I don't have the time to add one now.