### PR TITLE
Add support for `tracked-built-ins` v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "stylelint-config-standard": "^34.0.0",
         "stylelint-prettier": "^4.1.0",
         "svg-symbols": "^1.0.5",
-        "tracked-built-ins": "^3.3.0",
+        "tracked-built-ins": "^4.1.0",
         "typescript": "~5.5.0",
         "typescript-eslint": "^8.13.0",
         "webpack": "^5.95.0"
@@ -113,7 +113,7 @@
       },
       "peerDependencies": {
         "ember-source": "^4.12.0 || ^5.0.0 || ^6.0.0",
-        "tracked-built-ins": "^3.3.0"
+        "tracked-built-ins": "^3.3.0 || ^4.1.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2721,12 +2721,12 @@
       }
     },
     "node_modules/@embroider/addon-shim": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.10.0.tgz",
-      "integrity": "sha512-gcJuHiXgnrzaU8NyU+2bMbtS6PNOr5v5B8OXBqaBvTCsMpXLvKo8OBOQFCoUN0rPX2J6VaFqrbi/371sMvzZug==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.10.2.tgz",
+      "integrity": "sha512-EfI9cJ5/3QSUJtwm7x1MXrx3TEa2p7RNgSHefy7fvGm8/DP1xUFL25nST1NaHbHcqR1UhMlrTtv5iUIDoVzeQQ==",
       "license": "MIT",
       "dependencies": {
-        "@embroider/shared-internals": "^3.0.0",
+        "@embroider/shared-internals": "^3.0.1",
         "broccoli-funnel": "^3.0.8",
         "common-ancestor-path": "^1.0.1",
         "semver": "^7.3.8"
@@ -2833,12 +2833,12 @@
       }
     },
     "node_modules/@embroider/macros": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.19.1.tgz",
-      "integrity": "sha512-KgPan7fiyoDGfr6SMdMELhcgUXK6pU/QICSK0yFFzsXVBJYM2fHAXCic5WCBETtv7xsvi4byziahSz5HpqYs/A==",
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.19.6.tgz",
+      "integrity": "sha512-yPf8lD/gRZmcxms66CCKuZuvWMJ0g/hdCE6P8FZsyewR3So6pxgdgOFp0zk2w5d34jS1ejBtxLNREZbBTELpzw==",
       "license": "MIT",
       "dependencies": {
-        "@embroider/shared-internals": "3.0.1",
+        "@embroider/shared-internals": "3.0.2",
         "assert-never": "^1.2.1",
         "babel-import-util": "^3.0.1",
         "ember-cli-babel": "^7.26.6",
@@ -3080,9 +3080,9 @@
       }
     },
     "node_modules/@embroider/shared-internals": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-3.0.1.tgz",
-      "integrity": "sha512-d7RQwDwqqHo7YvjE9t1rtIrCCYtbSoO0uRq2ikVhRh4hGS5OojZNu2ZtS0Wqrg+V72CRtMFr/hibTvHNsRM2Lg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-3.0.2.tgz",
+      "integrity": "sha512-/SusdG+zgosc3t+9sPFVKSFOYyiSgLfXOT6lYNWoG1YtnhWDxlK4S8leZ0jhcVjemdaHln5rTyxCnq8oFLxqpQ==",
       "license": "MIT",
       "dependencies": {
         "babel-import-util": "^3.0.1",
@@ -3949,6 +3949,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@glimmer/tracking/-/tracking-1.1.2.tgz",
       "integrity": "sha512-cyV32zsHh+CnftuRX84ALZpd2rpbDrhLhJnTXn9W//QpqdRZ5rdMsxSY9fOsj0CKEc706tmEU299oNnDc0d7tA==",
+      "dev": true,
       "dependencies": {
         "@glimmer/env": "^0.1.7",
         "@glimmer/validator": "^0.44.0"
@@ -7043,138 +7044,11 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/@storybook/builder-webpack5/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/@storybook/builder-webpack5/node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/serialize-javascript": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
-      "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/terser": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.21.0.tgz",
-      "integrity": "sha512-WtnFKrxu9kaoXuiZFSGrcAvvBqAdmKx0SFNmVNYdJamMu9yyN3I/QF0FbH4QcqJQ+y1CJnzxGIKH0cSj+FGYRw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/terser-webpack-plugin": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
-      "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.17",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.1",
-        "terser": "^5.16.8"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@storybook/channel-postmessage": {
       "version": "6.5.13",
@@ -10328,72 +10202,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@storybook/manager-webpack5/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/@storybook/manager-webpack5/node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@storybook/manager-webpack5/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/@storybook/manager-webpack5/node_modules/serialize-javascript": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
-      "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
-    "node_modules/@storybook/manager-webpack5/node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/@storybook/manager-webpack5/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10404,58 +10212,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@storybook/manager-webpack5/node_modules/terser": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.21.0.tgz",
-      "integrity": "sha512-WtnFKrxu9kaoXuiZFSGrcAvvBqAdmKx0SFNmVNYdJamMu9yyN3I/QF0FbH4QcqJQ+y1CJnzxGIKH0cSj+FGYRw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@storybook/manager-webpack5/node_modules/terser-webpack-plugin": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
-      "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.17",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.1",
-        "terser": "^5.16.8"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
       }
     },
     "node_modules/@storybook/mdx1-csf": {
@@ -23059,26 +22815,25 @@
       }
     },
     "node_modules/ember-file-upload": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-9.1.0.tgz",
-      "integrity": "sha512-2t/LRpdbYP3GUnkUexjpWs/hE2QZeLh+Y3vM8GTzsyg+uYOaVNd4JFWrlFkazmo0Vp6Lf0rL+1Yj4tiefc+djQ==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-9.5.0.tgz",
+      "integrity": "sha512-qcYAuaA4MsmGzTaGgaC/KWAPh3Gc/rwl3h9YgI8pHP2AbLSrJ3Ichi73nr71NrUerYLZ3ccmT6M0ohPKaTeXIg==",
+      "license": "MIT",
       "dependencies": {
-        "@ember/test-waiters": "^3.0.0",
+        "@ember/test-waiters": "^3.0.0 || ^4.0.0",
         "@embroider/addon-shim": "^1.5.0",
-        "@embroider/macros": "^1.0.0",
-        "ember-auto-import": "^2.0.0"
+        "@embroider/macros": "^1.0.0"
       },
       "engines": {
         "node": "16.* || >= 18"
       },
       "peerDependencies": {
-        "@ember/test-helpers": "^2.9.3 || ^3.0.3 || ^4.0.4",
-        "@glimmer/component": "^1.1.2",
-        "@glimmer/tracking": "^1.1.2",
+        "@ember/test-helpers": "^2.9.3 || ^3.0.3 || ^4.0.4 || ^5.0.0",
+        "@glimmer/component": ">=1.1.2",
         "ember-cli-mirage": "*",
         "ember-modifier": "^3.2.7 || ^4.1.0",
         "miragejs": "*",
-        "tracked-built-ins": "^3.1.1"
+        "tracked-built-ins": ">=3.1.1"
       },
       "peerDependenciesMeta": {
         "ember-cli-mirage": {
@@ -43451,11 +43206,13 @@
       "dev": true
     },
     "node_modules/tracked-built-ins": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/tracked-built-ins/-/tracked-built-ins-3.3.0.tgz",
-      "integrity": "sha512-ewKFrW/AQs05oLPM5isOUb/1aOwBRfHfmF408CCzTk21FLAhKrKVOP5Q5ebX+zCT4kvg81PGBGwrBiEGND1nWA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tracked-built-ins/-/tracked-built-ins-4.1.0.tgz",
+      "integrity": "sha512-v1+jca3sD3LgbAFVsontSONTv7HsZll3yeUB00L6KPwLilFRrY77gvgptDe35fTalk9ea7mmrM2wABD56pTvuw==",
+      "license": "MIT",
       "dependencies": {
-        "@embroider/addon-shim": "^1.8.3",
+        "@embroider/addon-shim": "^1.10.2",
+        "decorator-transforms": "^2.0.0",
         "ember-tracked-storage-polyfill": "^1.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "stylelint-config-standard": "^34.0.0",
     "stylelint-prettier": "^4.1.0",
     "svg-symbols": "^1.0.5",
-    "tracked-built-ins": "^3.3.0",
+    "tracked-built-ins": "^4.1.0",
     "typescript": "~5.5.0",
     "typescript-eslint": "^8.13.0",
     "webpack": "^5.95.0"
@@ -185,7 +185,7 @@
   },
   "peerDependencies": {
     "ember-source": "^4.12.0 || ^5.0.0 || ^6.0.0",
-    "tracked-built-ins": "^3.3.0"
+    "tracked-built-ins": "^3.3.0 || ^4.1.0"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
We don't use the dependency ourselves, and ember-file-upload also added support for it. This allows apps to update their version as well.