### PR TITLE
Fix a whitespace issue in the `AuIcon` component

### DIFF
--- a/appuniversum/src/components/au-icon.gts
+++ b/appuniversum/src/components/au-icon.gts
@@ -52,7 +52,7 @@ export default class AuIcon extends Component<AuIconSignature> {
           aria-hidden={{this.ariaHidden}}
           ...attributes
         />
-      {{/let}}
+      {{~/let~}}
     {{~else~}}
       <svg
         role="img"


### PR DESCRIPTION
When the user provides their own icon it can result in unintended whitespace.

Closes #584 