### PR TITLE
`AuDataTable` pagination improvements

### DIFF
--- a/appuniversum/src/components/au-data-table.gjs
+++ b/appuniversum/src/components/au-data-table.gjs
@@ -123,6 +123,7 @@ export default class AuDataTable extends DataTable {
             @sizeOptions={{this.sizeOptions}}
             @total={{this.content.meta.count}}
             @links={{this.content.meta.pagination}}
+            @showBoundaryLinks={{this.showPaginationBoundaryLinks}}
           />
         </div>
       {{/if}}

--- a/appuniversum/src/components/au-data-table/number-pagination.gjs
+++ b/appuniversum/src/components/au-data-table/number-pagination.gjs
@@ -7,6 +7,8 @@ import { on } from '@ember/modifier';
 import AuButton from '../au-button.gts';
 import { NavLeftIcon } from '../icons/nav-left.gts';
 import { NavRightIcon } from '../icons/nav-right.gts';
+import { NavLeftDoubleIcon } from '../icons/nav-left-double.gts';
+import { NavRightDoubleIcon } from '../icons/nav-right-double.gts';
 
 // Source: https://github.com/mu-semtech/ember-data-table/blob/c690a3948b2d9d5f91d69f0a935c6b5cdb4862ca/addon/components/number-pagination.js
 const Base = Component.extend({
@@ -60,43 +62,77 @@ export default class NumberPagination extends Base {
   <template>
     <div class="au-c-pagination">
       <p>
-        <span class="au-u-hidden-visually">Rij </span><strong>{{this.startItem}}
+        <span class="au-u-hidden-visually">Rij</span>
+        <strong>
+          {{this.startItem}}
           -
-          {{this.endItem}}</strong>
+          {{this.endItem}}
+        </strong>
         van
         {{this.totalItems}}
       </p>
       <ul class="au-c-pagination__list">
-        {{#if this.hasMultiplePages}}
-          {{#unless this.isFirstPage}}
-            <li class="au-c-pagination__list-item">
-              <AuButton
-                @skin="link"
-                @icon={{NavLeftIcon}}
-                {{on "click" (fn this.changePage this.links.prev)}}
-              >
-                vorige
-                <span class="au-u-hidden-visually">
-                  {{this.pageSize}}
-                  rijen</span>
-              </AuButton>
-            </li>
-          {{/unless}}
-          {{#unless this.isLastPage}}
-            <li class="au-c-pagination__list-item">
-              <AuButton
-                @skin="link"
-                @icon={{NavRightIcon}}
-                @iconAlignment="right"
-                {{on "click" (fn this.changePage this.links.next)}}
-              >
-                volgende
-                <span class="au-u-hidden-visually">
-                  {{this.pageSize}}
-                  rijen</span>
-              </AuButton>
-            </li>
-          {{/unless}}
+        {{#if this.showBoundaryLinks}}
+          <li class="au-c-pagination__list-item au-c-pagination-boundary-link">
+            <AuButton
+              @skin="link-bold"
+              @icon={{NavLeftDoubleIcon}}
+              @disabled={{this.isFirstPage}}
+              {{on "click" (fn this.changePage this.links.first)}}
+            >
+              Eerste
+              <span class="au-u-hidden-visually">
+                {{this.pageSize}}
+                rijen
+              </span>
+            </AuButton>
+          </li>
+        {{/if}}
+        <li class="au-c-pagination__list-item">
+          <AuButton
+            @skin="link-bold"
+            @icon={{NavLeftIcon}}
+            @disabled={{this.isFirstPage}}
+            {{on "click" (fn this.changePage this.links.prev)}}
+          >
+            Vorige
+            <span class="au-u-hidden-visually">
+              {{this.pageSize}}
+              rijen
+            </span>
+          </AuButton>
+        </li>
+        <li class="au-c-pagination__list-item">
+          <AuButton
+            @skin="link-bold"
+            @icon={{NavRightIcon}}
+            @iconAlignment="right"
+            @disabled={{this.isLastPage}}
+            {{on "click" (fn this.changePage this.links.next)}}
+          >
+            Volgende
+            <span class="au-u-hidden-visually">
+              {{this.pageSize}}
+              rijen
+            </span>
+          </AuButton>
+        </li>
+        {{#if this.showBoundaryLinks}}
+          <li class="au-c-pagination__list-item au-c-pagination-boundary-link">
+            <AuButton
+              @skin="link-bold"
+              @icon={{NavRightDoubleIcon}}
+              @iconAlignment="right"
+              @disabled={{this.isLastPage}}
+              {{on "click" (fn this.changePage this.links.last)}}
+            >
+              Laatste
+              <span class="au-u-hidden-visually">
+                {{this.pageSize}}
+                rijen
+              </span>
+            </AuButton>
+          </li>
         {{/if}}
       </ul>
     </div>

--- a/appuniversum/src/components/au-data-table/number-pagination.gjs
+++ b/appuniversum/src/components/au-data-table/number-pagination.gjs
@@ -40,8 +40,8 @@ const Base = Component.extend({
   startItem: computed('size', 'currentPage', function () {
     return this.size * (this.currentPage - 1) + 1;
   }),
-  endItem: computed('startItem', 'nbOfItems', function () {
-    return this.startItem + this.nbOfItems - 1;
+  endItem: computed('startItem', 'size', 'totalItems', function () {
+    return Math.min(this.startItem + this.size - 1, this.totalItems);
   }),
   pageOptions: computed('firstPage', 'lastPage', function () {
     const nbOfPages = this.lastPage - this.firstPage + 1;

--- a/appuniversum/styles/components/_c-pagination.scss
+++ b/appuniversum/styles/components/_c-pagination.scss
@@ -10,10 +10,10 @@
 
 .au-c-pagination {
   @include au-font-size(var(--au-h6));
-  color: var(--au-gray-700);
   display: flex;
   justify-content: space-between;
   width: 100%;
+  container-type: inline-size;
 }
 
 .au-c-pagination__list {
@@ -21,10 +21,9 @@
   justify-content: flex-start;
 }
 
-.au-c-pagination__list-item {
-  & + & {
-    margin-left: $au-unit-tiny;
-    padding-left: $au-unit-tiny;
-    border-left: 0.1rem solid var(--au-divider-color);
+@container (width < 500px) {
+  // On very small container sizes we hide the first/last page links since they are less useful than the next/previous links.
+  .au-c-pagination-boundary-link {
+    display: none;
   }
 }

--- a/appuniversum/tests/integration/components/au-data-table-test.gjs
+++ b/appuniversum/tests/integration/components/au-data-table-test.gjs
@@ -1,7 +1,8 @@
 import AuDataTable from '#src/components/au-data-table';
-import { render } from '@ember/test-helpers';
+import { getRootElement, render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import { queryByText } from '@testing-library/dom';
 
 module('Integration | Component | au-data-table', function (hooks) {
   setupRenderingTest(hooks);
@@ -61,5 +62,50 @@ module('Integration | Component | au-data-table', function (hooks) {
       .doesNotExist(
         'the pagination bar is hidden when `@hidePagination` is true',
       );
+  });
+
+  test('it conditionally shows the first and last pagination links', async function (assert) {
+    const content = [{ name: 'foo' }, { name: 'bar' }];
+    content.meta = {
+      pagination: {
+        first: { number: 1 },
+        last: { number: 10 },
+      },
+    };
+
+    await render(
+      <template>
+        <AuDataTable @fields="name" @content={{content}} @enableSizes="false" />
+      </template>,
+    );
+
+    const root = getRootElement();
+    let firstButton = queryByText(root, 'Eerste');
+    let lastButton = queryByText(root, 'Laatste');
+
+    assert.notOk(
+      firstButton,
+      'The "Eerste" pagination link is hidden by default',
+    );
+    assert.notOk(
+      lastButton,
+      'The "Laatste" pagination link is hidden by default',
+    );
+
+    await render(
+      <template>
+        <AuDataTable
+          @fields="name"
+          @content={{content}}
+          @showPaginationBoundaryLinks={{true}}
+        />
+      </template>,
+    );
+
+    firstButton = queryByText(root, 'Eerste');
+    lastButton = queryByText(root, 'Laatste');
+
+    assert.dom(firstButton).exists();
+    assert.dom(lastButton).exists();
   });
 });

--- a/appuniversum/tests/integration/components/au-data-table/au-data-table-number-pagination-test.gjs
+++ b/appuniversum/tests/integration/components/au-data-table/au-data-table-number-pagination-test.gjs
@@ -15,7 +15,7 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    test('it conditionally shows buttons to change the page', async function (assert) {
+    test('it conditionally disables buttons to change the page', async function (assert) {
       const baseLinks = {
         first: {
           number: 0,
@@ -45,21 +45,32 @@ module(
             @size={{10}}
             @nbOfItems={{10}}
             @total={{100}}
+            @showBoundaryLinks={{true}}
           />
         </template>,
       );
 
       const root = getRootElement();
-      let prevButton = queryByText(root, 'vorige');
-      let nextButton = queryByText(root, 'volgende');
+      const firstButton = queryByText(root, 'Eerste');
+      const prevButton = queryByText(root, 'Vorige');
+      const nextButton = queryByText(root, 'Volgende');
+      const lastButton = queryByText(root, 'Laatste');
 
       assert.ok(
         prevButton,
         "It shows a button to go to the previous page when we aren't on the first page",
       );
       assert.ok(
+        firstButton,
+        "It shows a button to go to the first page when we aren't on the first page",
+      );
+      assert.ok(
         nextButton,
         "It shows a button to go to the next page when we aren't on the last page",
+      );
+      assert.ok(
+        lastButton,
+        "It shows a button to go to the last page when we aren't on the first page",
       );
 
       await click(prevButton);
@@ -78,14 +89,19 @@ module(
 
       await settled();
 
-      prevButton = queryByText(root, 'vorige');
-      assert.notOk(
-        prevButton,
-        'It hides the button to go to the previous page when we are on the first page',
-      );
+      assert
+        .dom(firstButton)
+        .isDisabled(
+          'It disables the button to go to the first page when we are on the first page',
+        );
+      assert
+        .dom(prevButton)
+        .isDisabled(
+          'It disables the button to go to the previous page when we are on the first page',
+        );
 
-      nextButton = queryByText(root, 'volgende');
-      assert.ok(nextButton);
+      assert.dom(nextButton).isNotDisabled();
+      assert.dom(lastButton).isNotDisabled();
 
       await click(nextButton);
       assert.equal(
@@ -106,8 +122,8 @@ module(
 
       await settled();
 
-      prevButton = queryByText(root, 'vorige');
-      assert.ok(prevButton);
+      assert.dom(firstButton).isNotDisabled();
+      assert.dom(prevButton).isNotDisabled();
 
       state.page = 9;
       state.links = {
@@ -119,11 +135,20 @@ module(
 
       await settled();
 
-      nextButton = queryByText(root, 'volgende');
-      assert.notOk(
-        nextButton,
-        'It hides the button to go to the next page when we are on the last page',
-      );
+      assert
+        .dom(nextButton)
+        .isDisabled(
+          'It disables the button to go to the next page when we are on the last page',
+        );
+
+      assert
+        .dom(lastButton)
+        .isDisabled(
+          'It disables the button to go to the last page when we are on the last page',
+        );
+
+      assert.dom(firstButton).isNotDisabled();
+      assert.dom(prevButton).isNotDisabled();
     });
   },
 );

--- a/docs-app/stories/5-components/Tables/AuDataTable.stories.js
+++ b/docs-app/stories/5-components/Tables/AuDataTable.stories.js
@@ -17,6 +17,7 @@ const Template = (args) => ({
       @noDataMessage="Geen documenten"
       @sort={{this.sort}}
       @hidePagination={{this.hidePagination}}
+      @showPaginationBoundaryLinks={{this.showPaginationBoundaryLinks}}
       as |t|
     >
       <t.menu as |menu|>
@@ -109,4 +110,5 @@ Component.args = {
   itemsPerPage: 5,
   totalItems: 100,
   hidePagination: false,
+  showPaginationBoundaryLinks: false,
 };


### PR DESCRIPTION
- styling improvements to match WebUniversum
- option to display pagination links to the first and last pages -> `@showPaginationBoundaryLinks={{true}}`. This might become the default in the future, if most projects want this.
- always display the pagination link, but disable them when needed instead.
- Capitalize the link labels
- fix an issue with the row information numbers
<img width="1184" height="126" alt="image" src="https://github.com/user-attachments/assets/6ebf4e4e-7d49-476e-8b8b-63a1629c82d3" />
